### PR TITLE
Fix Pomodoro break duration

### DIFF
--- a/apps/extension/src/services/focus.ts
+++ b/apps/extension/src/services/focus.ts
@@ -13,7 +13,8 @@ import { Timer } from '@/time/timer'
 import type { Mode, PomodoroState } from '@/modules/focus/types'
 
 const WORK_DURATION = 25 * 60 * 1000
-const BREAK_DURATION = 65 * 1000 // 5 * 60 * 1000
+// break duration defaults to five minutes
+const BREAK_DURATION = 5 * 60 * 1000
 
 const browserAction = browser.action ?? browser.browserAction
 


### PR DESCRIPTION
## Summary
- adjust break timer constant so breaks last 5 minutes

## Testing
- `npm --workspaces --if-present --silent run test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_686034b208b083289ca1c6d555012cec