### PR TITLE
Fix knex config variable name

### DIFF
--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -1,4 +1,4 @@
 import knex from 'knex'
-import knefConfig from '../knexfile'
+import knexConfig from '../knexfile'
 
-export const db = knex(knefConfig.development)
+export const db = knex(knexConfig.development)


### PR DESCRIPTION
## Summary
- fix typo in database config import

## Testing
- `npm test -w @odysea/server` *(fails: vitest not found)*
- `npm run lint -w @odysea/server` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686038968ed48328b0cbec910212038e