### PR TITLE
Add turbo configuration for linting and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "dev": "npm run -w @odysea/extension dev",
     "storybook": "npm run -w @odysea/extension storybook",
     "start-server": "npm run -w @odysea/server start",
-    "serverless:dev": "npm run -w @odysea/serverless dev"
+    "serverless:dev": "npm run -w @odysea/serverless dev",
+    "test": "turbo run test",
+    "lint": "turbo run lint"
   },
   "repository": {
     "type": "git",
@@ -31,5 +33,8 @@
   "bugs": {
     "url": "https://github.com/melledijkstra/kiekeboe/issues"
   },
-  "homepage": "https://github.com/melledijkstra/kiekeboe#readme"
+  "homepage": "https://github.com/melledijkstra/kiekeboe#readme",
+  "devDependencies": {
+    "turbo": "^1.11.3"
+  }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "lint": {
+      "dependsOn": ["^lint"],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^test"],
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add turbo to root scripts so lint and test run across workspaces
- create `turbo.json` with lint and test pipeline

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f00d199c83288de60a7559cf7bd8