### PR TITLE
Refactor Unsplash caching

### DIFF
--- a/apps/extension/src/api/image-cache.ts
+++ b/apps/extension/src/api/image-cache.ts
@@ -1,0 +1,52 @@
+import browser from 'webextension-polyfill'
+import { DAILY_IMAGE_KEY, NEXT_IMAGE_KEY } from '@/constants'
+import { log, Logger } from '@/logger'
+
+export type ImageInfo = {
+  id: string
+  url: string
+  date?: string
+}
+
+export class ImageCache {
+  private logger = new Logger('ImageCache')
+
+  async getDailyImageInfo(): Promise<ImageInfo | undefined> {
+    const { [DAILY_IMAGE_KEY]: storedImage } = (await browser.storage.local.get(
+      DAILY_IMAGE_KEY
+    )) as { [DAILY_IMAGE_KEY]?: ImageInfo }
+    return storedImage
+  }
+
+  async setDailyImageInfo(info: ImageInfo): Promise<void> {
+    await browser.storage.local.set({ [DAILY_IMAGE_KEY]: info })
+    this.logger.log('stored daily image', info)
+  }
+
+  async getNextImageInfo(): Promise<ImageInfo | undefined> {
+    const { [NEXT_IMAGE_KEY]: storedNext } = (await browser.storage.local.get(
+      NEXT_IMAGE_KEY
+    )) as { [NEXT_IMAGE_KEY]?: ImageInfo }
+    return storedNext
+  }
+
+  async setNextImageInfo(info: ImageInfo): Promise<void> {
+    await browser.storage.local.set({ [NEXT_IMAGE_KEY]: info })
+    this.logger.log('stored next image', info)
+  }
+
+  async clearDailyImage(): Promise<void> {
+    await browser.storage.local.remove(DAILY_IMAGE_KEY)
+    this.logger.log('Daily image cleared from storage')
+  }
+
+  async clearNextImage() {
+    await browser.storage.local.remove(NEXT_IMAGE_KEY)
+    log('Next image cleared from storage')
+  }
+
+  async clearImageCache() {
+    await browser.storage.local.remove([DAILY_IMAGE_KEY, NEXT_IMAGE_KEY])
+    log('Daily and next images cleared from storage')
+  }
+}

--- a/apps/extension/src/components/Curtain.svelte
+++ b/apps/extension/src/components/Curtain.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { UnsplashClient } from '@/api/unsplash'
+  import { updateBackgroundImage } from '@/ui'
 
   let client = $state<UnsplashClient>()
   let loaded = $state(false)
@@ -19,7 +20,7 @@
     const url = await client?.getDailyImage()
 
     if (url) {
-      client?.loadImage(url, () => {
+      updateBackgroundImage(url, () => {
         loaded = true
       })
     }

--- a/apps/extension/src/components/ImageRefreshButton.svelte
+++ b/apps/extension/src/components/ImageRefreshButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { UnsplashClient } from '@/api/unsplash'
+  import { updateBackgroundImage } from '@/ui'
   import IconButton from './atoms/IconButton.svelte'
   import { mdiCameraRetakeOutline } from '@mdi/js'
   import { settings } from '@/settings/index.svelte'
@@ -10,7 +11,7 @@
   async function refreshBackround() {
     const url = await unsplashClient?.refreshDailyImage()
     if (url) {
-      unsplashClient?.loadImage(url)
+      updateBackgroundImage(url)
     }
   }
 

--- a/apps/extension/src/ui.ts
+++ b/apps/extension/src/ui.ts
@@ -27,3 +27,13 @@ export function getWelcomeMessage(name: string): string {
 
   return `Good ${momentOfDay}, ${name}`
 }
+
+export function updateBackgroundImage(url: string, callback?: () => void) {
+  const image = new Image()
+  image.src = url
+  image.onload = () => {
+    callback?.()
+    const elem = document.querySelector(':root') as HTMLElement
+    elem?.style.setProperty('--background-image', `url(${url})`)
+  }
+}


### PR DESCRIPTION
## Summary
- adjust `ImageCache` to only manage browser storage
- update `UnsplashClient` to handle fetch logic and use the revised cache

## Testing
- `npx tsc -p apps/extension/tsconfig.json --noEmit` *(fails: Property 'update' does not exist on type 'SpotifyState')*

------
https://chatgpt.com/codex/tasks/task_e_6860f063fe708328a5db1494d492c46f