### PR TITLE
Refactor stores with generic helper

### DIFF
--- a/apps/extension/src/modules/habits/Habits.svelte
+++ b/apps/extension/src/modules/habits/Habits.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Panel from '@/components/atoms/Panel.svelte'
   import IconButton from '@/components/atoms/IconButton.svelte'
-  import { addNewHabit, habits, initializeHabits } from '@/stores/habits.svelte'
+  import { habits } from '@/stores/habits.svelte'
   import { mdiInfinity } from '@mdi/js'
   import { onMount } from 'svelte'
 
@@ -9,12 +9,12 @@
   let open = $state(false)
 
   onMount(() => {
-    initializeHabits()
+    habits.initialize()
   })
 
   async function handleAddHabit() {
     if (newHabit.trim()) {
-      await addNewHabit({
+      await habits.add({
         name: newHabit,
         color: '#eee',
         dateCreated: new Date()

--- a/apps/extension/src/modules/notes/Notes.svelte
+++ b/apps/extension/src/modules/notes/Notes.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import TextButton from '@/components/TextButton.svelte'
-  import { addNewNote, initializeNotes, notes } from '@/stores/notes.svelte'
+  import { notes } from '@/stores/notes.svelte'
   import { formatDate } from '@/date'
 
   let open = $state(false)
@@ -9,7 +9,7 @@
   let inputText = $state('')
 
   function createNote() {
-    addNewNote({
+    notes.add({
       title: inputTitle,
       text: inputText,
       dateCreated: new Date()
@@ -19,7 +19,7 @@
   }
 
   onMount(async () => {
-    initializeNotes()
+    notes.initialize()
   })
 </script>
 

--- a/apps/extension/src/stores/createDbStore.ts
+++ b/apps/extension/src/stores/createDbStore.ts
@@ -1,0 +1,27 @@
+import { writable, type Writable } from 'svelte/store'
+
+export function createDbStore<T>(
+  fetchAll: () => Promise<T[]>,
+  addItem: (item: T) => Promise<void>
+) {
+  const { subscribe, set, update }: Writable<T[]> = writable([])
+
+  async function initialize() {
+    const items = await fetchAll()
+    set(items)
+  }
+
+  async function add(item: T) {
+    await addItem(item)
+    const items = await fetchAll()
+    set(items)
+  }
+
+  return {
+    subscribe,
+    set,
+    update,
+    initialize,
+    add
+  }
+}

--- a/apps/extension/src/stores/habits.svelte.ts
+++ b/apps/extension/src/stores/habits.svelte.ts
@@ -1,19 +1,4 @@
-import {
-  addHabit,
-  getAllHabits,
-  type Habit,
-} from '@/db/habits'
-import { writable } from 'svelte/store'
+import { addHabit, getAllHabits, type Habit } from '@/db/habits'
+import { createDbStore } from './createDbStore'
 
-export const habits = writable<Habit[]>([])
-
-export async function initializeHabits() {
-  const loadedHabits = await getAllHabits()
-  habits.set(loadedHabits)
-}
-
-export async function addNewHabit(habit: Habit) {
-  await addHabit(habit)
-  const updatedHabits = await getAllHabits()
-  habits.set(updatedHabits)
-}
+export const habits = createDbStore<Habit>(getAllHabits, addHabit)

--- a/apps/extension/src/stores/notes.svelte.ts
+++ b/apps/extension/src/stores/notes.svelte.ts
@@ -1,15 +1,4 @@
-import { addNote, getAllNotes, type Note } from "@/db/notes";
-import { writable } from "svelte/store";
+import { addNote, getAllNotes, type Note } from '@/db/notes'
+import { createDbStore } from './createDbStore'
 
-export const notes = writable<Note[]>([])
-
-export async function initializeNotes() {
-  const loadedHabits = await getAllNotes()
-  notes.set(loadedHabits)
-}
-
-export async function addNewNote(note: Note) {
-  await addNote(note)
-  const updatedHabits = await getAllNotes()
-  notes.set(updatedHabits)
-}
+export const notes = createDbStore<Note>(getAllNotes, addNote)


### PR DESCRIPTION
## Summary
- add generic `createDbStore` factory to eliminate duplication in Svelte stores
- refactor habit and note stores to use the new helper
- update habit and note module components to use the new API

## Testing
- `npm test` *(fails: JSR package manifest could not load)*

------
https://chatgpt.com/codex/tasks/task_e_686646f51f8c832883ff41d11d521f36