### PR TITLE
Fix command center execute logic

### DIFF
--- a/apps/extension/src/modules/command-center/commands.service.ts
+++ b/apps/extension/src/modules/command-center/commands.service.ts
@@ -88,20 +88,16 @@ export class CommandService implements CommandServiceInterface, ILogger {
   }
 
   execute(input: string): void {
-    let commandItem: CommandItem | undefined;
+    const commandItem = this.findCommand(input)
 
     if (!commandItem) {
       addToast('Command not recognized. Please try again.')
       return
     }
 
-    if (commandItem) {
-      const prompt = input?.split(' ').slice(1).join(' ').trim()
-      this.logger.log(`Executing command: ${commandItem.name} with prompt: ${prompt}`)
-      commandItem.action();
-    } else {
-      console.warn(`Command not found for input: ${input}`);
-    }
+    const prompt = input?.split(' ').slice(1).join(' ').trim()
+    this.logger.log(`Executing command: ${commandItem.name} with prompt: ${prompt}`)
+    commandItem.action(prompt)
   }
 
   findCommand(input: string): CommandItem | undefined {


### PR DESCRIPTION
## Summary
- ensure execute uses `findCommand` and passes prompt to the action

## Testing
- `npm test` *(fails: JSR package manifest could not load)*

------
https://chatgpt.com/codex/tasks/task_e_686647136e788328bbdbe6fdc2d62196