### PR TITLE
Add Cache API for newtab background image

### DIFF
--- a/apps/extension/src/background.entry.ts
+++ b/apps/extension/src/background.entry.ts
@@ -1,9 +1,15 @@
+/// <reference lib="webworker" />
 import browser from 'webextension-polyfill'
 import { FocusService } from '@/services/focus'
-import { Logger } from './logger'
-import { commandCenterOpen } from './modules/command-center/messages'
-import { settings } from './settings/index.svelte'
-import { cacheImage } from '@/cache/messages'
+import { Logger } from '@/logger'
+import { commandCenterOpen } from '@/modules/command-center/messages'
+import { settings } from '@/settings/index.svelte'
+import { findExtensionTab, getActiveTab, isHomepageUrl } from '@/background/utils'
+import { trimCache } from './background/image-cache'
+
+const UNSPLASH_IMAGE_DOMAIN = 'https://images.unsplash.com'
+
+declare const self: ServiceWorkerGlobalScope;
 
 export const logger = new Logger('background')
 
@@ -12,30 +18,6 @@ declare global {
 }
 
 const services = []
-
-cacheImage.on(async (url) => {
-  logger.log('cacheImage request received', url)
-  if (!url) return ''
-  const cache = await caches.open('image-cache')
-  const match = await cache.match(url)
-  if (match) {
-    const data = await match.blob()
-    return blobToDataUrl(data)
-  }
-  const response = await fetch(url)
-  await cache.put(url, response.clone())
-  const blob = await response.blob()
-  return blobToDataUrl(blob)
-})
-
-function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onloadend = () => resolve(reader.result as string)
-    reader.onerror = () => reject(new Error('Failed to read blob'))
-    reader.readAsDataURL(blob)
-  })
-}
 
 browser.runtime.onInstalled.addListener(({ reason }) => {
   logger.log('Extension installed:', reason)
@@ -49,25 +31,6 @@ browser.runtime.onInstalled.addListener(({ reason }) => {
     })
   }
 })
-
-async function getActiveTab() {
-  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-  return tabs[0];
-}
-
-async function findExtensionTab() {
-  const tabs = await browser.tabs.query({});
-  const extensionUrl = `chrome-extension://${browser.runtime.id}/index.html`;
-
-  return tabs.find(tab =>
-    tab.url?.startsWith(extensionUrl) || tab.url?.startsWith('chrome://newtab')
-  );
-}
-
-function isHomepageUrl(url: string) {
-  return url.startsWith(`chrome-extension://${browser.runtime.id}/index.html`) ||
-  url.startsWith('chrome://newtab')
-}
 
 browser.commands.onCommand.addListener(async (command) => {
   logger.log('Command received:', command)
@@ -102,6 +65,33 @@ browser.notifications.onClicked.addListener((notificationId) => {
   logger.log('Notification clicked:', notificationId)
   browser.tabs.create({ url: '/index.html' })
 })
+
+self.addEventListener('fetch', (event) => {
+  const url = event.request.url;
+
+  if (url.startsWith(UNSPLASH_IMAGE_DOMAIN)) {
+    event.respondWith((async () => {
+      const imageCache = await caches.open('image-cache')
+      const match = await imageCache.match(event.request)
+      if (match) {
+        logger.log('Serving cached image:', event.request.url)
+        return match
+      }
+      const response = await fetch(event.request)
+      imageCache.put(event.request, response.clone())
+      return response
+    })())
+  }
+})
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', e => {
+  // clean up any stale entries right away
+  e.waitUntil(trimCache());
+});
 
 logger.log('Service worker activated')
 services.push(new FocusService())

--- a/apps/extension/src/background/image-cache.ts
+++ b/apps/extension/src/background/image-cache.ts
@@ -1,0 +1,28 @@
+const CACHE_NAME = 'image-cache';
+const MAX_ENTRIES = 20; // max number of images
+const MAX_AGE_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+export async function trimCache() {
+  const cache = await caches.open(CACHE_NAME);
+  const requests = await cache.keys();
+  const now = Date.now();
+
+  // 1) Remove by age (using server Date header if present)
+  for (const req of requests) {
+    const resp = await cache.match(req);
+    if (!resp) continue;
+    const dateHdr = resp.headers.get('Date');
+    if (dateHdr) {
+      const fetchedAt = new Date(dateHdr).getTime();
+      if (now - fetchedAt > MAX_AGE_SECONDS * 1000) {
+        await cache.delete(req);
+      }
+    }
+  }
+
+  // 2) Enforce max entries (oldest-first)
+  const remaining = [...await cache.keys()];
+  while (remaining.length > MAX_ENTRIES) {
+    await cache.delete(remaining.shift()!);
+  }
+}

--- a/apps/extension/src/background/utils.ts
+++ b/apps/extension/src/background/utils.ts
@@ -1,0 +1,21 @@
+import type Browser from 'webextension-polyfill';
+import browser from 'webextension-polyfill'
+
+export const isHomepageUrl = (url: string) =>
+  url.startsWith(`chrome-extension://${browser.runtime.id}/index.html`) ||
+  url.startsWith('chrome://newtab')
+
+
+export async function findExtensionTab(): Promise<Browser.Tabs.Tab | undefined> {
+  const tabs = await browser.tabs.query({});
+  const extensionUrl = `chrome-extension://${browser.runtime.id}/index.html`;
+
+  return tabs.find(tab =>
+    tab.url?.startsWith(extensionUrl) || tab.url?.startsWith('chrome://newtab')
+  );
+}
+
+export async function getActiveTab() {
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  return tabs[0];
+}

--- a/apps/extension/src/cache/messages.ts
+++ b/apps/extension/src/cache/messages.ts
@@ -1,3 +1,0 @@
-import { createMessage } from '@/messaging'
-
-export const cacheImage = createMessage<string, string>('cacheImage')

--- a/apps/extension/src/cache/messages.ts
+++ b/apps/extension/src/cache/messages.ts
@@ -1,0 +1,3 @@
+import { createMessage } from '@/messaging'
+
+export const cacheImage = createMessage<string, string>('cacheImage')

--- a/apps/extension/src/components/Curtain.svelte
+++ b/apps/extension/src/components/Curtain.svelte
@@ -1,30 +1,23 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { UnsplashClient } from '@/api/unsplash'
-  import { updateBackgroundImage } from '@/ui'
+  import { setBackgroundImage } from '@/ui'
 
-  let client = $state<UnsplashClient>()
+  let client = $state<UnsplashClient>(new UnsplashClient())
   let loaded = $state(false)
 
-  onMount(() => {
-    client = new UnsplashClient()
-
+  onMount(async () => {
     if (document.body.id !== 'curtain-image') {
       document.body.id = 'curtain-image'
     }
-    
-    setBackgroundImage()
-  })
 
-  async function setBackgroundImage() {
     const url = await client?.getDailyImage()
 
     if (url) {
-      updateBackgroundImage(url, () => {
-        loaded = true
-      })
+      await setBackgroundImage(url)
+      loaded = true
     }
-  }
+  })
 </script>
 
 <style lang="postcss">

--- a/apps/extension/src/components/ImageRefreshButton.svelte
+++ b/apps/extension/src/components/ImageRefreshButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { UnsplashClient } from '@/api/unsplash'
-  import { updateBackgroundImage } from '@/ui'
+  import { setBackgroundImage } from '@/ui'
   import IconButton from './atoms/IconButton.svelte'
   import { mdiCameraRetakeOutline } from '@mdi/js'
   import { settingsStore } from '@/settings/index.svelte'
@@ -19,7 +19,7 @@
   async function refreshBackround() {
     const url = await unsplashClient?.refreshDailyImage()
     if (url) {
-      updateBackgroundImage(url)
+      setBackgroundImage(url)
     }
   }
 

--- a/apps/extension/src/logger.ts
+++ b/apps/extension/src/logger.ts
@@ -36,4 +36,22 @@ export class Logger {
   error(...data: unknown[]) {
     error(`[${this.name}]`, ...data)
   }
+
+  private generateLabel(label?: string): string {
+    return label ? `[${this.name}] ${label}` : `[${this.name}]`
+  }
+
+  time(label?: string) {
+    if (this.disabled) {
+      return
+    }
+    console.time(this.generateLabel(label))
+  }
+
+  timeEnd(label?: string) {
+    if (this.disabled) {
+      return
+    }
+    console.timeEnd(this.generateLabel(label))
+  }
 }

--- a/apps/extension/src/messaging/index.ts
+++ b/apps/extension/src/messaging/index.ts
@@ -32,8 +32,8 @@ export function createMessage<Request = void, Response = void>(identifier: strin
             Promise.resolve(promise).then((r) => {
               sendResponse(r)
             })
-            return true
           }
+          return true
         }
       )
     }

--- a/apps/extension/src/modules/command-center/messages.ts
+++ b/apps/extension/src/modules/command-center/messages.ts
@@ -1,3 +1,3 @@
-import { createMessage } from "@/messaging/system";
+import { createMessage } from "@/messaging";
 
 export const commandCenterOpen = createMessage<void, void>('commandCenterOpen');

--- a/apps/extension/src/modules/focus/messages.ts
+++ b/apps/extension/src/modules/focus/messages.ts
@@ -1,5 +1,5 @@
 import type { Mode, PomodoroState } from '@/modules/focus/types'
-import { createMessage } from '@/messaging/system'
+import { createMessage } from '@/messaging'
 
 export const startPomodoro = createMessage<void, void>('startPomodoro')
 

--- a/apps/extension/src/ui.test.ts
+++ b/apps/extension/src/ui.test.ts
@@ -48,13 +48,16 @@ describe('ui.ts', () => {
     })
   })
 
-  describe('updateBackgroundImage', () => {
+  describe('setBackgroundImage', () => {
     let originalImage: typeof globalThis.Image;
 
     beforeEach(() => {
       originalImage = globalThis.Image;
       vi.stubGlobal('Image', class {
         _src: string = '';
+        get src() {
+          return this._src;
+        }
         set src(value: string) {
           this._src = value;
           // Simulate image loading
@@ -73,7 +76,7 @@ describe('ui.ts', () => {
       vi.unstubAllGlobals();
     })
 
-    it('should update the background image', async () => {
+    it('should set the background image', async () => {
       // setup
       const mockUrl = 'https://example.com/image.jpg'
       const mockRootElement = document.createElement('div')

--- a/apps/extension/src/ui.test.ts
+++ b/apps/extension/src/ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { retrieveUsername, storeUsername, getWelcomeMessage, updateBackgroundImage } from './ui'
+import { retrieveUsername, storeUsername, getWelcomeMessage, setBackgroundImage } from './ui'
 import browser from 'webextension-polyfill'
 import { NAME_STORAGE_KEY } from './constants';
 
@@ -73,19 +73,17 @@ describe('ui.ts', () => {
       vi.unstubAllGlobals();
     })
 
-    it('should update the background image and call the callback', async () => {
+    it('should update the background image', async () => {
       // setup
       const mockUrl = 'https://example.com/image.jpg'
-      const mockCallback = vi.fn()
       const mockRootElement = document.createElement('div')
       mockRootElement.style.setProperty = vi.fn()
       document.querySelector = vi.fn().mockReturnValue(mockRootElement)
 
       // act
-      await updateBackgroundImage(mockUrl, mockCallback)
+      await setBackgroundImage(mockUrl)
 
       // assert
-      expect(mockCallback).toHaveBeenCalled()
       expect(mockRootElement.style.setProperty).toHaveBeenCalledWith('--background-image', `url(${mockUrl})`)
     })
   })

--- a/apps/extension/src/ui.ts
+++ b/apps/extension/src/ui.ts
@@ -47,6 +47,7 @@ async function fetchImage(src: string): Promise<string> {
 
 function setSrc(src: string) {
   const elem = document.querySelector(':root') as HTMLElement
+
   if (!elem) {
     logger.error('Root element not found for setting background image')
     return
@@ -56,9 +57,6 @@ function setSrc(src: string) {
 }
 
 export async function setBackgroundImage(url: string) {
-  logger.time('updateBackgroundImage')
-  fetchImage(url).then((src) => {
-    setSrc(src)
-    logger.timeEnd('updateBackgroundImage')
-  })
+  const src = await fetchImage(url)
+  setSrc(src)
 }

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ESNext",
     "resolveJsonModule": true,
     "strictNullChecks": true,
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "Webworker"],
     "types": ["vite/client", "@types/chrome"],
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.


### PR DESCRIPTION
## Summary
- add message helper to request cached images from the background
- implement Cache Storage API logic in the background service worker
- use cached image data when setting the background

## Testing
- `npm test` *(fails: JSR package manifest for '@hono/hono' failed to load)*
- `npm run lint`
- `npm run -s build`


------
https://chatgpt.com/codex/tasks/task_e_68666d8d1d888328bb8fad1b8b5e5efb