### PR TITLE
Implement Google tasks CRUD operations

### DIFF
--- a/apps/extension/src/api/google/tasks.ts
+++ b/apps/extension/src/api/google/tasks.ts
@@ -64,8 +64,25 @@ export class TasksClient extends TokenBaseClient {
     }
   }
 
-  async updateTask(task: Task) {
-    throw new Error('Update Task not implemented yet!' + task.id)
+  async updateTask(task: Task, taskListId?: string): Promise<Task | undefined> {
+    try {
+      const response = await this.request<Task>(
+        `/lists/${taskListId ?? '@default'}/tasks/${task.id}?alt=json`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(task)
+        }
+      )
+
+      if (response) {
+        return response
+      }
+    } catch (error) {
+      console.error('Error updating task', error)
+    }
   }
 
   async createTask(
@@ -88,5 +105,22 @@ export class TasksClient extends TokenBaseClient {
     } catch (error) {
       console.error('Error creating a task', error)
     }
+  }
+
+  async deleteTask(
+    task: string | Task,
+    taskListId?: string
+  ): Promise<boolean> {
+    const id = typeof task === 'string' ? task : task.id
+    try {
+      await this.request(
+        `/lists/${taskListId ?? '@default'}/tasks/${id}`,
+        { method: 'DELETE' }
+      )
+      return true
+    } catch (error) {
+      console.error('Error deleting task', error)
+    }
+    return false
   }
 }

--- a/apps/extension/src/modules/google-tasks/Tasks.svelte
+++ b/apps/extension/src/modules/google-tasks/Tasks.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import browser from 'webextension-polyfill'
   import { TasksClient } from '@/api/google/tasks'
+  import type { TaskList, Task } from '@/api/definitions/google'
   import TextButton from '@/components/TextButton.svelte'
   import { log } from '@/logger'
   import { AuthClient } from '@/oauth2/auth'
@@ -8,16 +9,31 @@
   import { onMount } from 'svelte'
   import { tasks } from '@/stores/tasks.svelte'
   import AuthButton from '@/components/AuthButton.svelte'
-
+  
   const authClient = new AuthClient(new GoogleAuthProvider())
 
   let open = $state(false)
   let token = $state<string>()
   let taskClient = $state<TasksClient | null>(null)
   let inputTask = $state('')
+  let taskLists = $state<TaskList[]>([])
+  let selectedTaskList = $state<string>('')
+  let editingTask = $state<string | null>(null)
+  let editingTitle = $state('')
+
+  async function loadTaskLists() {
+    const data = await taskClient?.getTaskLists()
+    if (data) {
+      taskLists = data
+      if (!selectedTaskList && data.length > 0) {
+        selectedTaskList = data[0].id
+        await loadTasks()
+      }
+    }
+  }
 
   async function loadTasks() {
-    const data = await taskClient?.fetchTasks()
+    const data = await taskClient?.fetchTasks(selectedTaskList)
     log('tasks loaded', $tasks)
     if (data) {
       $tasks = data
@@ -26,7 +42,7 @@
 
   async function createTask(e: KeyboardEvent) {
     if (e.key === 'Enter' && inputTask) {
-      const newTask = await taskClient?.createTask(inputTask)
+      const newTask = await taskClient?.createTask(inputTask, selectedTaskList)
       if (newTask) {
         $tasks = [newTask, ...$tasks]
       }
@@ -38,15 +54,37 @@
     const status = (event.target as HTMLInputElement).checked
       ? 'completed'
       : 'needsAction'
-    const updatedTask = await taskClient?.setTaskStatus(taskId, status)
+    const updatedTask = await taskClient?.setTaskStatus(taskId, status, selectedTaskList)
     if (updatedTask) {
       $tasks = $tasks.map((task) => (task.id === taskId ? updatedTask : task))
+    }
+  }
+
+  async function saveEdit(task: Task) {
+    if (!editingTitle) return
+    const updated = await taskClient?.updateTask(
+      { ...task, title: editingTitle },
+      selectedTaskList
+    )
+    if (updated) {
+      $tasks = $tasks.map((t) => (t.id === updated.id ? updated : t))
+    }
+    editingTask = null
+    editingTitle = ''
+  }
+
+  async function removeTask(taskId: string) {
+    const success = await taskClient?.deleteTask(taskId, selectedTaskList)
+    if (success) {
+      $tasks = $tasks.filter((t) => t.id !== taskId)
     }
   }
 
   async function triggerAuthFlow() {
     token = await authClient.getAuthToken(true)
     if (token) {
+      taskClient = new TasksClient(token)
+      await loadTaskLists()
       loadTasks()
     }
   }
@@ -55,6 +93,7 @@
     token = await authClient.getAuthToken()
     if (token) {
       taskClient = new TasksClient(token)
+      await loadTaskLists()
       loadTasks()
     }
   })
@@ -77,6 +116,11 @@
         />
         Tasks
       </h3>
+      <select class="mb-2 text-black" bind:value={selectedTaskList} on:change={loadTasks}>
+        {#each taskLists as list (list.id)}
+          <option value={list.id}>{list.title}</option>
+        {/each}
+      </select>
       <ul class="task-list">
         {#each $tasks as task (task.id)}
           <li class="flex items-center gap-1 my-1 text-sm text-white">
@@ -85,7 +129,19 @@
               onchange={(event) => toggleTask(event, task.id)}
               checked={task.status === 'completed'}
             />
-            {task.title}
+            {#if editingTask === task.id}
+              <input
+                class="flex-1 bg-transparent border-b text-white"
+                bind:value={editingTitle}
+                on:keypress={(e) => e.key === 'Enter' && saveEdit(task)}
+              />
+              <button class="text-xs" onclick={() => saveEdit(task)}>Save</button>
+            {:else}
+              <span class="flex-1" on:dblclick={() => { editingTask = task.id; editingTitle = task.title }}>
+                {task.title}
+              </span>
+            {/if}
+            <button class="text-red-500 text-xs" onclick={() => removeTask(task.id)}>x</button>
           </li>
         {/each}
         <input


### PR DESCRIPTION
## Summary
- implement update and delete endpoints for Google Tasks API
- add UI for switching task lists and editing/deleting tasks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869280bfe6483288373cdfd35933c39