### PR TITLE
Add popup player for browser extension

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -14,6 +14,7 @@ Kiekeboe is a personal homepage extension that enhances your new tab page with a
 - **Weather Widget**: Displays current weather conditions and forecasts for your location.
 - **Quick Notes**: Allows you to jot down notes directly on the homepage.
 - **Pomodoro Timer**: Helps you stay focused with a built-in Pomodoro timer.
+- **Popup Controls**: Quickly control Spotify playback and focus mode from the browser toolbar popup.
 
 ### Modules
 

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -20,7 +20,8 @@
       "32": "icons/icon32.png",
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
-    }
+    },
+    "default_popup": "popup.html"
   },
   "options_page": "options.html",
   "options_ui": {

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kiekeboe Popup</title>
+    <title>Popup</title>
   </head>
   <body>
     <script type="module">

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kiekeboe Popup</title>
+  </head>
+  <body>
+    <script type="module">
+      import { mount } from 'svelte'
+      import Popup from './src/Popup.svelte'
+      import '@/app.css'
+
+      mount(Popup, { target: document.body })
+    </script>
+  </body>
+</html>

--- a/apps/extension/src/Popup.svelte
+++ b/apps/extension/src/Popup.svelte
@@ -1,27 +1,28 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte'
-  import MusicPlayer from '@/components/musicplayer/MusicPlayer.svelte'
-  import { SpotifyController } from '@/controllers/SpotifyController'
-  import Pomodoro from '@/modules/focus/Pomodoro.svelte'
+  import { onMount } from "svelte"
+  import { appState } from "./app-state.svelte"
+  import { getPomodoroState } from "./modules/focus/messages"
+  import type { PomodoroState } from "./modules/focus/types"
+  import { Timer } from "./time/timer"
 
-  let spotify = $state<SpotifyController>(new SpotifyController())
+  let pomodoroState = $state<PomodoroState>()
 
-  function cleanup() {
-    spotify.destroy()
-  }
-
-  onMount(() => {
-    spotify.initialize()
+  onMount(async () => {
+    const state = await getPomodoroState.send()
+    pomodoroState = state
   })
-
-  onDestroy(cleanup)
 </script>
 
-<div class="w-96 p-2 space-y-4 bg-zinc-900 text-white">
-  {#if SpotifyController.hasLockAcquired()}
-    <MusicPlayer controller={spotify} />
+<div class="w-96 p-2 space-y-2 bg-zinc-900 text-white">
+  <h1 class="text-2xl font-bold">Popup Extension</h1>
+  <p>City: {appState.geolocation?.city}</p>
+  <p>App mode: {appState.mode}</p>
+  <h2 class="text-1xl font-bold">Pomodoro</h2>
+  {#if !pomodoroState}
+    <p>Loading...</p>
   {:else}
-    <p class="text-center">Spotify player active in another tab</p>
+    <p>Running?: {pomodoroState.isRunning}</p>
+    <p>mode: {pomodoroState.mode}</p>
+    <p>{Timer.formatRemainingTime(pomodoroState.timeRemaining)}</p>
   {/if}
-  <Pomodoro onMinutePassed={() => {}} />
 </div>

--- a/apps/extension/src/Popup.svelte
+++ b/apps/extension/src/Popup.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte'
+  import MusicPlayer from '@/components/musicplayer/MusicPlayer.svelte'
+  import { SpotifyController } from '@/controllers/SpotifyController'
+  import Pomodoro from '@/modules/focus/Pomodoro.svelte'
+
+  let spotify = $state<SpotifyController>(new SpotifyController())
+
+  function cleanup() {
+    spotify.destroy()
+  }
+
+  onMount(() => {
+    spotify.initialize()
+  })
+
+  onDestroy(cleanup)
+</script>
+
+<div class="w-96 p-2 space-y-4 bg-zinc-900 text-white">
+  {#if SpotifyController.hasLockAcquired()}
+    <MusicPlayer controller={spotify} />
+  {:else}
+    <p class="text-center">Spotify player active in another tab</p>
+  {/if}
+  <Pomodoro onMinutePassed={() => {}} />
+</div>

--- a/apps/extension/src/components/musicplayer/Playback.svelte
+++ b/apps/extension/src/components/musicplayer/Playback.svelte
@@ -53,8 +53,8 @@
   })
   let mediaItem = $derived(state?.currentItem)
   let position_ms = $derived(state?.position_ms ?? 0)
-  let remaining = $derived(mediaItem ? mediaItem.duration_ms - position_ms : 0)
-  let timeLeft = $derived<string>(millisecondsToTime(remaining))
+  // let remaining = $derived(mediaItem ? mediaItem.duration_ms - position_ms : 0)
+  // let timeLeft = $derived<string>(millisecondsToTime(remaining))
   let duration = $derived(mediaItem?.duration_ms ? millisecondsToTime(mediaItem.duration_ms) : 0)
   let currentTime = $derived<string>(millisecondsToTime(position_ms))
 </script>

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -36,6 +36,7 @@ const defaultConfig = defineConfig(({ mode }) => ({
         home: './index.html',
         options: './options.html',
         background: './src/background.entry.ts',
+        popup: './popup.html',
       },
       output: {
         entryFileNames: '[name].js',


### PR DESCRIPTION
## Summary
- add popup to quickly control Spotify player and focus timer
- update manifest and build config for the new popup
- document popup controls in extension README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68692a0f7c288328a626c33f0593bab5