### PR TITLE
Add Time Tools extension module

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -24,6 +24,7 @@ Kiekeboe is a personal homepage extension that enhances your new tab page with a
 - Spotify: Offers in-page Spotify playback controls.
 - World Clocks: Displays local times from multiple time zones.
 - Fitbit: Retrieves your daily sleep statistics.
+- Time Tools: Provides alarms, a timer and a chronometer.
 
 ## Installation
 

--- a/apps/extension/src/background.entry.ts
+++ b/apps/extension/src/background.entry.ts
@@ -1,6 +1,7 @@
 /// <reference lib="webworker" />
 import browser from 'webextension-polyfill'
 import { FocusService } from '@/services/focus'
+import { TimeToolsService } from '@/services/time-tools'
 import { Logger } from '@/logger'
 import { commandCenterOpen } from '@/modules/command-center/messages'
 import { settings } from '@/settings/index.svelte'
@@ -95,6 +96,7 @@ self.addEventListener('activate', e => {
 
 logger.log('Service worker activated')
 services.push(new FocusService())
+services.push(new TimeToolsService())
 
 if (import.meta.env.DEV) {
   // add global r() function to make development easier reloading

--- a/apps/extension/src/components/atoms/Input.svelte
+++ b/apps/extension/src/components/atoms/Input.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { HTMLLabelAttributes, HTMLInputAttributes } from 'svelte/elements';
 
-  let { value = $bindable<string>(), label = null, labelProps = {}, ...props }: {
-    value?: string;
+  let { value = $bindable<string | number>(), label = null, labelProps = {}, ...props }: {
+    value?: string | number;
     label?: string | null;
     labelProps?: HTMLLabelAttributes;
   } & HTMLInputAttributes = $props()

--- a/apps/extension/src/components/topbar/TopBar.svelte
+++ b/apps/extension/src/components/topbar/TopBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { loadModule, type ModuleID } from '@/modules'
-  import { mdiHomeOutline, mdiSpa, mdiSprout } from '@mdi/js'
+  import { mdiHomeOutline } from '@mdi/js'
   import { appState, switchAppMode } from '@/app-state.svelte'
   import { settingsStore } from '@/settings/index.svelte'
   import MetricsPanel from '@/modules/trackers/MetricsPanel.svelte'
@@ -13,7 +13,7 @@
 {#snippet module(moduleId: ModuleID)}
   {#if $settingsStore.modules?.[moduleId]}
     {#await loadModule(moduleId) then Module}
-      <Module.component />
+      <Module.trigger />
     {/await}
   {/if}
 {/snippet}
@@ -32,20 +32,9 @@
       tooltip="Home"
       mdiIcon={mdiHomeOutline}
     />
-    {#if $settingsStore.modules.focus}
-      <MenuButton
-        tooltip="Focus"
-        onclick={() => switchAppMode('focus')}
-        mdiIcon={mdiSprout}
-      />
-    {/if}
-    {#if $settingsStore.modules.well_being}
-      <MenuButton
-        tooltip="Breathing"
-        onclick={() => switchAppMode('breathing')}
-        mdiIcon={mdiSpa}
-      />
-    {/if}
+    {@render module('focus')}
+    {@render module('well_being')}
+    {@render module('time_tools')}
   </div>
   <div
     class={[

--- a/apps/extension/src/modules/focus/FocusMenuItem.svelte
+++ b/apps/extension/src/modules/focus/FocusMenuItem.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { switchAppMode } from '@/app-state.svelte'
+  import MenuButton from '@/components/atoms/MenuButton.svelte'
+  import { mdiSprout } from '@mdi/js'
+</script>
+
+<MenuButton
+  tooltip="Focus"
+  onclick={() => switchAppMode('focus')}
+  mdiIcon={mdiSprout}
+/>

--- a/apps/extension/src/modules/focus/Pomodoro.svelte
+++ b/apps/extension/src/modules/focus/Pomodoro.svelte
@@ -12,7 +12,6 @@
   } from './messages'
   import type { PomodoroState } from './types'
   import { resetTitle, setTitle } from '@/app-state.svelte'
-  import Panel from '@/components/atoms/Panel.svelte'
   import { log } from '@/logger'
 
   const { onMinutePassed } = $props()
@@ -77,10 +76,8 @@
 </script>
 
 <div class="flex flex-col gap justify-center items-center">
-  <Panel class="text-2xl">
-    <span class="capitalize">{pState.mode}</span>
-    <span>{timeLeft}</span>
-  </Panel>
+  <span class="capitalize">{pState.mode}</span>
+  <span>{timeLeft}</span>
   <div class="flex flex-row gap-2 mt-2">
     <button
       onclick={pState.isRunning ? stop : start}

--- a/apps/extension/src/modules/focus/index.ts
+++ b/apps/extension/src/modules/focus/index.ts
@@ -1,7 +1,9 @@
 import type { Module } from '@/modules'
 import Focus from './Focus.svelte'
+import FocusMenuItem from './FocusMenuItem.svelte'
 
 export default {
   component: Focus,
-  scene: Focus
+  scene: Focus,
+  trigger: FocusMenuItem
 } satisfies Module

--- a/apps/extension/src/modules/index.ts
+++ b/apps/extension/src/modules/index.ts
@@ -54,6 +54,11 @@ export const MODULE_CONFIG = [
     id: 'weather',
     title: 'Weather',
     import: () => import('./weather/index.ts')
+  },
+  {
+    id: 'time_tools',
+    title: 'Time Tools',
+    import: () => import('./time-tools/index.ts')
   }
 ] as const satisfies ReadonlyArray<ModuleConfigItem>
 

--- a/apps/extension/src/modules/index.ts
+++ b/apps/extension/src/modules/index.ts
@@ -6,10 +6,10 @@ const logger = new Logger('modules')
 /**
  * MODULE INTERFACE
  */
-
 export interface Module {
   component: Component
   scene?: Component
+  trigger?: Component
   init?: () => void
 }
 

--- a/apps/extension/src/modules/spotify/index.ts
+++ b/apps/extension/src/modules/spotify/index.ts
@@ -2,7 +2,8 @@ import type { Module } from '@/modules'
 import SpotifyMenuItem from './SpotifyMenuItem.svelte'
 
 const module: Module = {
-  component: SpotifyMenuItem
+  component: SpotifyMenuItem,
+  trigger: SpotifyMenuItem
 }
 
 export default module

--- a/apps/extension/src/modules/time-tools/TimeToolsMenuItem.svelte
+++ b/apps/extension/src/modules/time-tools/TimeToolsMenuItem.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { mdiAlarm, mdiTimerOutline, mdiClockOutline } from '@mdi/js'
+  import IconButton from '@/components/atoms/IconButton.svelte'
+  import Panel from '@/components/atoms/Panel.svelte'
+  import Button from '@/components/atoms/Button.svelte'
+  import Input from '@/components/atoms/Input.svelte'
+  import { onMount } from 'svelte'
+  import {
+    startTimer,
+    stopTimer,
+    timerStateUpdate,
+    getTimerState,
+    startChronometer,
+    stopChronometer,
+    chronometerStateUpdate,
+    getChronometerState,
+    setAlarm,
+    clearAlarm,
+    getAlarmState,
+    alarmStateUpdate,
+    alarmTriggered
+  } from './messages'
+  import type { TimerState, ChronometerState, AlarmState } from './types'
+  import { Timer } from '@/time/timer'
+  import { formatSeconds } from '@/time/utils'
+
+  let open = $state(false)
+  let timerMinutes = $state(1)
+  let timerState = $state<TimerState>({ isRunning: false, duration: 0, timeRemaining: 0 })
+  let chronometerState = $state<ChronometerState>({ isRunning: false, elapsed: 0 })
+  let alarmInput = $state('')
+  let alarmState = $state<AlarmState>({ alarmTime: null, triggered: false })
+
+  function toggle() {
+    open = !open
+  }
+
+  function startStopTimer() {
+    if (timerState.isRunning) {
+      stopTimer.send()
+    } else {
+      startTimer.send(timerMinutes * 60 * 1000)
+    }
+  }
+
+  function startStopChrono() {
+    if (chronometerState.isRunning) {
+      stopChronometer.send()
+    } else {
+      startChronometer.send()
+    }
+  }
+
+  function setAlarmTime() {
+    if (alarmInput) {
+      const [h, m] = alarmInput.split(':').map(Number)
+      const now = new Date()
+      const alarm = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m)
+      if (alarm.getTime() < now.getTime()) {
+        alarm.setDate(alarm.getDate() + 1)
+      }
+      setAlarm.send(alarm.getTime())
+    }
+  }
+
+  function clearAlarmTime() {
+    clearAlarm.send()
+  }
+
+  onMount(async () => {
+    timerState = await getTimerState.send()
+    chronometerState = await getChronometerState.send()
+    alarmState = await getAlarmState.send()
+    timerStateUpdate.on((s) => (timerState = s))
+    chronometerStateUpdate.on((s) => (chronometerState = s))
+    alarmStateUpdate.on((s) => (alarmState = s))
+    alarmTriggered.on(() => {
+      alert('Alarm!')
+    })
+  })
+</script>
+
+<div class="relative">
+  <IconButton icon={mdiTimerOutline} onclick={toggle} />
+  {#if open}
+    <Panel class="absolute right-0 z-50 w-64 p-4 flex flex-col space-y-4">
+      <div>
+        <h2 class="font-bold mb-1 flex items-center gap-1"><svg width="16" height="16"><path d={mdiTimerOutline} /></svg> Timer</h2>
+        <Input type="number" min="1" bind:value={timerMinutes} class="mb-2" />
+        <Button onclick={startStopTimer}>{timerState.isRunning ? 'Stop' : 'Start'}</Button>
+        <p class="mt-1">{Timer.formatRemainingTime(timerState.timeRemaining)}</p>
+      </div>
+      <hr />
+      <div>
+        <h2 class="font-bold mb-1 flex items-center gap-1"><svg width="16" height="16"><path d={mdiClockOutline} /></svg> Chronometer</h2>
+        <Button onclick={startStopChrono}>{chronometerState.isRunning ? 'Stop' : 'Start'}</Button>
+        <p class="mt-1">{formatSeconds(Math.floor(chronometerState.elapsed / 1000))}</p>
+      </div>
+      <hr />
+      <div>
+        <h2 class="font-bold mb-1 flex items-center gap-1"><svg width="16" height="16"><path d={mdiAlarm} /></svg> Alarm</h2>
+        <Input type="time" bind:value={alarmInput} class="mb-2" />
+        <div class="flex gap-2">
+          <Button onclick={setAlarmTime}>Set</Button>
+          <Button onclick={clearAlarmTime}>Clear</Button>
+        </div>
+        {#if alarmState.alarmTime}
+          <p class="mt-1">Alarm set for {new Date(alarmState.alarmTime).toLocaleTimeString()}</p>
+        {/if}
+        {#if alarmState.triggered}
+          <p class="mt-1 text-red-500">Alarm triggered!</p>
+        {/if}
+      </div>
+    </Panel>
+  {/if}
+</div>

--- a/apps/extension/src/modules/time-tools/TimeToolsMenuItem.svelte
+++ b/apps/extension/src/modules/time-tools/TimeToolsMenuItem.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { mdiAlarm, mdiTimerOutline, mdiClockOutline } from '@mdi/js'
   import IconButton from '@/components/atoms/IconButton.svelte'
-  import Panel from '@/components/atoms/Panel.svelte'
   import Button from '@/components/atoms/Button.svelte'
   import Input from '@/components/atoms/Input.svelte'
   import { onMount } from 'svelte'
@@ -23,17 +22,15 @@
   import type { TimerState, ChronometerState, AlarmState } from './types'
   import { Timer } from '@/time/timer'
   import { formatSeconds } from '@/time/utils'
+  import { Popover } from 'bits-ui'
+  import PopPanel from '@/components/atoms/PopPanel.svelte'
+  import Icon from '@/components/atoms/Icon.svelte'
 
-  let open = $state(false)
   let timerMinutes = $state(1)
   let timerState = $state<TimerState>({ isRunning: false, duration: 0, timeRemaining: 0 })
   let chronometerState = $state<ChronometerState>({ isRunning: false, elapsed: 0 })
   let alarmInput = $state('')
   let alarmState = $state<AlarmState>({ alarmTime: null, triggered: false })
-
-  function toggle() {
-    open = !open
-  }
 
   function startStopTimer() {
     if (timerState.isRunning) {
@@ -67,50 +64,56 @@
     clearAlarm.send()
   }
 
+  function timerUpdate(state: TimerState) {
+    Object.assign(timerState, state)
+  }
+
   onMount(async () => {
     timerState = await getTimerState.send()
     chronometerState = await getChronometerState.send()
     alarmState = await getAlarmState.send()
-    timerStateUpdate.on((s) => (timerState = s))
-    chronometerStateUpdate.on((s) => (chronometerState = s))
-    alarmStateUpdate.on((s) => (alarmState = s))
+    timerStateUpdate.on(timerUpdate)
+    chronometerStateUpdate.on((s) => Object.assign(chronometerState, s))
+    alarmStateUpdate.on((s) => Object.assign(alarmState, s))
     alarmTriggered.on(() => {
       alert('Alarm!')
     })
   })
 </script>
 
-<div class="relative">
-  <IconButton icon={mdiTimerOutline} onclick={toggle} />
-  {#if open}
-    <Panel class="absolute right-0 z-50 w-64 p-4 flex flex-col space-y-4">
-      <div>
-        <h2 class="font-bold mb-1 flex items-center gap-1"><svg width="16" height="16"><path d={mdiTimerOutline} /></svg> Timer</h2>
-        <Input type="number" min="1" bind:value={timerMinutes} class="mb-2" />
-        <Button onclick={startStopTimer}>{timerState.isRunning ? 'Stop' : 'Start'}</Button>
-        <p class="mt-1">{Timer.formatRemainingTime(timerState.timeRemaining)}</p>
+<Popover.Root>
+  <Popover.Trigger>
+    {#snippet child({ props })}
+      <IconButton icon={mdiTimerOutline} {...props} />
+    {/snippet}
+  </Popover.Trigger>
+  <PopPanel panelProps={{ size: 'medium' }}>
+    <div>
+      <h2 class="font-bold mb-1 flex items-center gap-1"><Icon path={mdiTimerOutline} /> Timer</h2>
+      <Input type="number" min="1" bind:value={timerMinutes} class="mb-2" />
+      <Button onclick={startStopTimer}>{timerState.isRunning ? 'Stop' : 'Start'}</Button>
+      <p class="mt-1">{Timer.formatRemainingTime(timerState.timeRemaining)}</p>
+    </div>
+    <hr />
+    <div>
+      <h2 class="font-bold mb-1 flex items-center gap-1"><Icon path={mdiClockOutline} /> Chronometer</h2>
+      <Button onclick={startStopChrono}>{chronometerState.isRunning ? 'Stop' : 'Start'}</Button>
+      <p class="mt-1">{formatSeconds(Math.floor(chronometerState.elapsed / 1000))}</p>
+    </div>
+    <hr />
+    <div>
+      <h2 class="font-bold mb-1 flex items-center gap-1"><Icon path={mdiAlarm} /> Alarm</h2>
+      <Input type="time" bind:value={alarmInput} class="mb-2" />
+      <div class="flex gap-2">
+        <Button onclick={setAlarmTime}>Set</Button>
+        <Button onclick={clearAlarmTime}>Clear</Button>
       </div>
-      <hr />
-      <div>
-        <h2 class="font-bold mb-1 flex items-center gap-1"><svg width="16" height="16"><path d={mdiClockOutline} /></svg> Chronometer</h2>
-        <Button onclick={startStopChrono}>{chronometerState.isRunning ? 'Stop' : 'Start'}</Button>
-        <p class="mt-1">{formatSeconds(Math.floor(chronometerState.elapsed / 1000))}</p>
-      </div>
-      <hr />
-      <div>
-        <h2 class="font-bold mb-1 flex items-center gap-1"><svg width="16" height="16"><path d={mdiAlarm} /></svg> Alarm</h2>
-        <Input type="time" bind:value={alarmInput} class="mb-2" />
-        <div class="flex gap-2">
-          <Button onclick={setAlarmTime}>Set</Button>
-          <Button onclick={clearAlarmTime}>Clear</Button>
-        </div>
-        {#if alarmState.alarmTime}
-          <p class="mt-1">Alarm set for {new Date(alarmState.alarmTime).toLocaleTimeString()}</p>
-        {/if}
-        {#if alarmState.triggered}
-          <p class="mt-1 text-red-500">Alarm triggered!</p>
-        {/if}
-      </div>
-    </Panel>
-  {/if}
-</div>
+      {#if alarmState.alarmTime}
+        <p class="mt-1">Alarm set for {new Date(alarmState.alarmTime).toLocaleTimeString()}</p>
+      {/if}
+      {#if alarmState.triggered}
+        <p class="mt-1 text-red-500">Alarm triggered!</p>
+      {/if}
+    </div>
+  </PopPanel>
+</Popover.Root>

--- a/apps/extension/src/modules/time-tools/index.ts
+++ b/apps/extension/src/modules/time-tools/index.ts
@@ -1,0 +1,7 @@
+import type { Module } from '@/modules'
+import TimeToolsMenuItem from './TimeToolsMenuItem.svelte'
+
+export default {
+  component: TimeToolsMenuItem,
+  scene: TimeToolsMenuItem
+} satisfies Module

--- a/apps/extension/src/modules/time-tools/index.ts
+++ b/apps/extension/src/modules/time-tools/index.ts
@@ -3,5 +3,5 @@ import TimeToolsMenuItem from './TimeToolsMenuItem.svelte'
 
 export default {
   component: TimeToolsMenuItem,
-  scene: TimeToolsMenuItem
+  trigger: TimeToolsMenuItem
 } satisfies Module

--- a/apps/extension/src/modules/time-tools/messages.ts
+++ b/apps/extension/src/modules/time-tools/messages.ts
@@ -3,6 +3,7 @@ import type { TimerState, ChronometerState, AlarmState } from './types'
 
 export const startTimer = createMessage<number, void>('timeToolsStartTimer')
 export const stopTimer = createMessage<void, void>('timeToolsStopTimer')
+
 export const getTimerState = createMessage<void, TimerState>('timeToolsGetTimerState')
 export const timerStateUpdate = createMessage<TimerState, void>('timeToolsTimerStateUpdate')
 

--- a/apps/extension/src/modules/time-tools/messages.ts
+++ b/apps/extension/src/modules/time-tools/messages.ts
@@ -1,0 +1,18 @@
+import { createMessage } from '@/messaging'
+import type { TimerState, ChronometerState, AlarmState } from './types'
+
+export const startTimer = createMessage<number, void>('timeToolsStartTimer')
+export const stopTimer = createMessage<void, void>('timeToolsStopTimer')
+export const getTimerState = createMessage<void, TimerState>('timeToolsGetTimerState')
+export const timerStateUpdate = createMessage<TimerState, void>('timeToolsTimerStateUpdate')
+
+export const startChronometer = createMessage<void, void>('timeToolsStartChronometer')
+export const stopChronometer = createMessage<void, void>('timeToolsStopChronometer')
+export const getChronometerState = createMessage<void, ChronometerState>('timeToolsGetChronometerState')
+export const chronometerStateUpdate = createMessage<ChronometerState, void>('timeToolsChronometerStateUpdate')
+
+export const setAlarm = createMessage<number, void>('timeToolsSetAlarm')
+export const clearAlarm = createMessage<void, void>('timeToolsClearAlarm')
+export const getAlarmState = createMessage<void, AlarmState>('timeToolsGetAlarmState')
+export const alarmTriggered = createMessage<void, void>('timeToolsAlarmTriggered')
+export const alarmStateUpdate = createMessage<AlarmState, void>('timeToolsAlarmStateUpdate')

--- a/apps/extension/src/modules/time-tools/tools/BaseTimeToolService.ts
+++ b/apps/extension/src/modules/time-tools/tools/BaseTimeToolService.ts
@@ -1,0 +1,19 @@
+import { Timer } from '@/time/timer'
+import type { TimeToolState } from '../types'
+
+export abstract class BaseTimeToolService<T extends TimeToolState> {
+  protected timer: Timer
+  protected state: T
+
+  constructor(timer: Timer, initialState: T) {
+    this.timer = timer
+    this.state = initialState
+    this.wireEvents()
+  }
+
+  protected abstract wireEvents(): void
+
+  abstract start(...args: unknown[]): void
+  abstract stop(): void
+  abstract getState(): T
+} 

--- a/apps/extension/src/modules/time-tools/tools/TimerToolService.ts
+++ b/apps/extension/src/modules/time-tools/tools/TimerToolService.ts
@@ -1,0 +1,56 @@
+import { BaseTimeToolService } from './BaseTimeToolService'
+import { Timer } from '@/time/timer'
+import type { TimeToolState } from '../types'
+import browser from 'webextension-polyfill'
+
+export class TimerToolService extends BaseTimeToolService<Extract<TimeToolState, { type: 'timer' }>> {
+  constructor() {
+    super(
+      new Timer({ duration: 0 }),
+      { type: 'timer', isRunning: false, duration: 0, timeRemaining: 0 }
+    )
+  }
+
+  protected wireEvents(): void {
+    this.timer.on('tick', (remaining) => {
+      this.state.timeRemaining = remaining
+      this.sendStateUpdate()
+    })
+    this.timer.on('complete', () => {
+      this.state.isRunning = false
+      this.state.timeRemaining = 0
+      this.sendStateUpdate()
+      browser.notifications.create('timeToolsTimer', {
+        type: 'basic',
+        title: 'Timer done',
+        message: 'The timer has finished',
+        iconUrl: browser.runtime.getURL('icons/bell.png')
+      })
+    })
+  }
+
+  start(duration: number): void {
+    this.timer.setDuration(duration)
+    this.timer.start()
+    this.state.isRunning = true
+    this.state.duration = duration
+    this.state.timeRemaining = duration
+    this.sendStateUpdate()
+  }
+
+  stop(): void {
+    this.timer.stop()
+    this.state.isRunning = false
+    this.state.timeRemaining = this.state.duration
+    this.sendStateUpdate()
+  }
+
+  getState() {
+    return this.state
+  }
+
+  private sendStateUpdate() {
+    // Placeholder for generic event/message handler
+    // e.g., this.messageHandler?.('timerStateUpdate', this.state)
+  }
+} 

--- a/apps/extension/src/modules/time-tools/types.ts
+++ b/apps/extension/src/modules/time-tools/types.ts
@@ -1,0 +1,15 @@
+export type TimerState = {
+  isRunning: boolean
+  duration: number
+  timeRemaining: number
+}
+
+export type ChronometerState = {
+  isRunning: boolean
+  elapsed: number
+}
+
+export type AlarmState = {
+  alarmTime: number | null
+  triggered: boolean
+}

--- a/apps/extension/src/modules/time-tools/types.ts
+++ b/apps/extension/src/modules/time-tools/types.ts
@@ -1,14 +1,25 @@
+// Unified state type for all time tools
+export type TimeToolState =
+  | { type: 'timer'; isRunning: boolean; duration: number; timeRemaining: number }
+  | { type: 'chronometer'; isRunning: boolean; elapsed: number }
+  | { type: 'alarm'; alarmTime: number | null; triggered: boolean }
+
+export type TimeToolType = TimeToolState['type']
+
+/** @deprecated use TimeToolState instead */
 export type TimerState = {
   isRunning: boolean
   duration: number
   timeRemaining: number
 }
 
+/** @deprecated use TimeToolState instead */
 export type ChronometerState = {
   isRunning: boolean
   elapsed: number
 }
 
+/** @deprecated use TimeToolState instead */
 export type AlarmState = {
   alarmTime: number | null
   triggered: boolean

--- a/apps/extension/src/modules/well-being/BreathingMenuItem.svelte
+++ b/apps/extension/src/modules/well-being/BreathingMenuItem.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { switchAppMode } from '@/app-state.svelte'
+  import MenuButton from '@/components/atoms/MenuButton.svelte'
+  import { mdiSpa } from '@mdi/js'
+</script>
+
+<MenuButton
+  tooltip="Breathing"
+  onclick={() => switchAppMode('breathing')}
+  mdiIcon={mdiSpa}
+/>

--- a/apps/extension/src/modules/well-being/index.ts
+++ b/apps/extension/src/modules/well-being/index.ts
@@ -1,7 +1,9 @@
 import type { Module } from '@/modules'
 import Breathing from './Breathing.svelte'
+import BreathingMenuItem from './BreathingMenuItem.svelte'
 
 export default {
   component: Breathing,
-  scene: Breathing
+  scene: Breathing,
+  trigger: BreathingMenuItem
 } satisfies Module

--- a/apps/extension/src/services/time-tools.ts
+++ b/apps/extension/src/services/time-tools.ts
@@ -1,0 +1,140 @@
+import browser from 'webextension-polyfill'
+import { Timer } from '@/time/timer'
+import type { BackgroundService } from '@/services/types'
+import {
+  startTimer,
+  stopTimer,
+  getTimerState,
+  timerStateUpdate,
+  startChronometer,
+  stopChronometer,
+  getChronometerState,
+  chronometerStateUpdate,
+  setAlarm,
+  clearAlarm,
+  getAlarmState,
+  alarmTriggered,
+  alarmStateUpdate
+} from '@/modules/time-tools/messages'
+import type { TimerState, ChronometerState, AlarmState } from '@/modules/time-tools/types'
+import { logger } from '@/background.entry'
+
+export class TimeToolsService implements BackgroundService {
+  private timer = new Timer({ duration: 0 })
+  private chronometer = new Timer({ duration: Infinity, interval: 1000 })
+  private timerState: TimerState = { isRunning: false, duration: 0, timeRemaining: 0 }
+  private chronometerState: ChronometerState = { isRunning: false, elapsed: 0 }
+  private alarmState: AlarmState = { alarmTime: null, triggered: false }
+  private alarmTimeout: number | null = null
+
+  constructor() {
+    logger.log('TimeTools service initialized')
+    this.timer.on('tick', this.onTimerTick.bind(this))
+    this.timer.on('complete', this.onTimerComplete.bind(this))
+    this.chronometer.on('tick', this.onChronometerTick.bind(this))
+
+    startTimer.on(this.startTimer.bind(this))
+    stopTimer.on(this.stopTimer.bind(this))
+    getTimerState.on(this.getTimerState.bind(this))
+
+    startChronometer.on(this.startChronometer.bind(this))
+    stopChronometer.on(this.stopChronometer.bind(this))
+    getChronometerState.on(this.getChronometerState.bind(this))
+
+    setAlarm.on(this.setAlarm.bind(this))
+    clearAlarm.on(this.clearAlarm.bind(this))
+    getAlarmState.on(this.getAlarmState.bind(this))
+  }
+
+  private onTimerTick(remaining: number) {
+    this.timerState.timeRemaining = remaining
+    timerStateUpdate.send(this.timerState)
+  }
+
+  private onTimerComplete() {
+    this.timerState.isRunning = false
+    this.timerState.timeRemaining = 0
+    timerStateUpdate.send(this.timerState)
+    browser.notifications.create('timeToolsTimer', {
+      type: 'basic',
+      title: 'Timer done',
+      message: 'The timer has finished',
+      iconUrl: browser.runtime.getURL('icons/bell.png')
+    })
+  }
+
+  private onChronometerTick() {
+    this.chronometerState.elapsed += 1000
+    chronometerStateUpdate.send(this.chronometerState)
+  }
+
+  private setAlarm(time: number) {
+    if (this.alarmTimeout) {
+      clearTimeout(this.alarmTimeout)
+    }
+    this.alarmState = { alarmTime: time, triggered: false }
+    const delay = Math.max(time - Date.now(), 0)
+    this.alarmTimeout = setTimeout(() => this.fireAlarm(), delay)
+    alarmStateUpdate.send(this.alarmState)
+  }
+
+  private clearAlarm() {
+    if (this.alarmTimeout) {
+      clearTimeout(this.alarmTimeout)
+      this.alarmTimeout = null
+    }
+    this.alarmState = { alarmTime: null, triggered: false }
+    alarmStateUpdate.send(this.alarmState)
+  }
+
+  private fireAlarm() {
+    this.alarmTimeout = null
+    this.alarmState.triggered = true
+    alarmStateUpdate.send(this.alarmState)
+    alarmTriggered.send()
+    browser.notifications.create('timeToolsAlarm', {
+      type: 'basic',
+      title: 'Alarm',
+      message: 'Your alarm is going off',
+      iconUrl: browser.runtime.getURL('icons/bell.png')
+    })
+  }
+
+  private startTimer(duration: number) {
+    this.timer.setDuration(duration)
+    this.timer.start()
+    this.timerState = { isRunning: true, duration, timeRemaining: duration }
+    timerStateUpdate.send(this.timerState)
+  }
+
+  private stopTimer() {
+    this.timer.stop()
+    this.timerState.isRunning = false
+    this.timerState.timeRemaining = this.timerState.duration
+    timerStateUpdate.send(this.timerState)
+  }
+
+  private startChronometer() {
+    this.chronometerState = { isRunning: true, elapsed: 0 }
+    this.chronometer.start()
+    chronometerStateUpdate.send(this.chronometerState)
+  }
+
+  private stopChronometer() {
+    this.chronometer.stop()
+    this.chronometerState.isRunning = false
+    chronometerStateUpdate.send(this.chronometerState)
+  }
+
+  private getTimerState(): TimerState {
+    return this.timerState
+  }
+
+  private getChronometerState(): ChronometerState {
+    return this.chronometerState
+  }
+
+  private getAlarmState(): AlarmState {
+    return this.alarmState
+  }
+}

--- a/apps/extension/src/settings/index.svelte.ts
+++ b/apps/extension/src/settings/index.svelte.ts
@@ -30,7 +30,8 @@ const DEFAULT_MODULE_SETTINGS: { [key in ModuleID]: boolean } = {
   weather: false,
   google_tasks: false,
   notes: false,
-  spotify: false
+  spotify: false,
+  time_tools: false
 }
 
 export const DEFAULT_SETTINGS: SettingsState = {


### PR DESCRIPTION
## Summary
- add Time Tools extension module with timer, chronometer and alarm
- implement TimeToolsService to handle timers in the background
- expose new messages and types for time tools
- register Time Tools module
- integrate service in background script
- document new module in README

## Testing
- `npm test --workspace=apps/extension`

------
https://chatgpt.com/codex/tasks/task_e_68715c3c88dc8328a2530dc43b839851