### PR TITLE
Add reactive background with fade transition

### DIFF
--- a/apps/extension/src/App.svelte
+++ b/apps/extension/src/App.svelte
@@ -2,6 +2,7 @@
   import { fade } from 'svelte/transition'
   import Clock from '@/components/Clock.svelte'
   import Curtain from '@/components/Curtain.svelte'
+  import Background from '@/components/Background.svelte'
   import Welcome from '@/components/Welcome.svelte'
   import { onMount } from 'svelte'
   import { settings, settingsStore } from '@/settings/index.svelte'
@@ -28,6 +29,7 @@
 </svelte:head>
 
 {#await settings.initialize() then}
+  <Background />
   <Curtain />
 
   <NotificationCenter position="bottom-right" />

--- a/apps/extension/src/components/Background.svelte
+++ b/apps/extension/src/components/Background.svelte
@@ -2,7 +2,7 @@
   import { backgroundImage } from '@/stores/background.svelte'
   import { fade } from 'svelte/transition'
 
-  let url = $derived(backgroundImage)
+  let url = $derived($backgroundImage)
 </script>
 
 {#if url}
@@ -11,6 +11,6 @@
       class="fixed inset-0 -z-20 bg-center bg-no-repeat bg-cover bg-fixed"
       style="background-image: url({url})"
       transition:fade={{ duration: 300 }}
-    />
+    ></div>
   {/key}
 {/if}

--- a/apps/extension/src/components/Background.svelte
+++ b/apps/extension/src/components/Background.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { backgroundImage } from '@/stores/background.svelte'
+  import { fade } from 'svelte/transition'
+
+  let url = $derived(backgroundImage)
+</script>
+
+{#if url}
+  {#key url}
+    <div
+      class="fixed inset-0 -z-20 bg-center bg-no-repeat bg-cover bg-fixed"
+      style="background-image: url({url})"
+      transition:fade={{ duration: 300 }}
+    />
+  {/key}
+{/if}

--- a/apps/extension/src/components/Curtain.svelte
+++ b/apps/extension/src/components/Curtain.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { UnsplashClient } from '@/api/unsplash'
-  import { setBackgroundImage } from '@/ui'
+  import { setBackgroundImage } from '@/stores/background.svelte'
 
   let client = $state<UnsplashClient>(new UnsplashClient())
   let loaded = $state(false)
 
   onMount(async () => {
-    if (document.body.id !== 'curtain-image') {
-      document.body.id = 'curtain-image'
-    }
-
     const url = await client?.getDailyImage()
 
     if (url) {
@@ -22,22 +18,6 @@
 
 <style lang="postcss">
   @reference '../app.css';
-  
-  :root {
-    --background-image: url();
-  }
-
-  :global {
-    #curtain-image {
-      @apply bg-black h-screen w-screen overflow-x-hidden;
-
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: cover;
-      background-attachment: fixed;
-      background-image: var(--background-image);
-    }
-  }
 </style>
 
 <div

--- a/apps/extension/src/components/Curtain.svelte
+++ b/apps/extension/src/components/Curtain.svelte
@@ -16,10 +16,6 @@
   })
 </script>
 
-<style lang="postcss">
-  @reference '../app.css';
-</style>
-
 <div
   class="fixed h-screen w-screen bg-black transition-opacity duration-300 top-0 left-0 -z-10 {loaded
     ? 'opacity-20'

--- a/apps/extension/src/components/ImageRefreshButton.svelte
+++ b/apps/extension/src/components/ImageRefreshButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { UnsplashClient } from '@/api/unsplash'
-  import { setBackgroundImage } from '@/ui'
+  import { setBackgroundImage } from '@/stores/background.svelte'
   import IconButton from './atoms/IconButton.svelte'
   import { mdiCameraRetakeOutline } from '@mdi/js'
   import { settingsStore } from '@/settings/index.svelte'

--- a/apps/extension/src/stores/background.svelte.test.ts
+++ b/apps/extension/src/stores/background.svelte.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { backgroundImage, setBackgroundImage } from './background.svelte'
+import type { Readable } from 'svelte/store'
+
+// Helper to subscribe and capture value
+function getStoreValue(store: Readable<string | undefined>): string | undefined {
+  let value: string | undefined
+  const unsub = store.subscribe((v) => (value = v))
+  unsub()
+  return value
+}
+
+describe('background.svelte store', () => {
+  let originalImage: typeof globalThis.Image
+
+  beforeEach(() => {
+    originalImage = globalThis.Image
+    vi.stubGlobal('Image', class {
+      _src: string = ''
+      get src() {
+        return this._src
+      }
+      set src(value: string) {
+        this._src = value
+        setTimeout(() => {
+          this.onload?.()
+        }, 0)
+      }
+      onload: (() => void) | null = null
+      onerror: ((error: Event) => void) | null = null
+    })
+  })
+
+  afterEach(() => {
+    globalThis.Image = originalImage
+    vi.unstubAllGlobals()
+  })
+
+  it('should have undefined as initial value', () => {
+    expect(getStoreValue(backgroundImage)).toBeUndefined()
+  })
+
+  it('should update store when setBackgroundImage is called with a valid URL', async () => {
+    const url = 'https://example.com/image.jpg'
+    let value: string | undefined
+    const unsub = backgroundImage.subscribe((v) => (value = v))
+    await setBackgroundImage(url)
+    expect(value).toBe(url)
+    unsub()
+  })
+
+  it('should allow multiple subscribers to receive updates', async () => {
+    const url = 'https://example.com/image2.jpg'
+    let value1: string | undefined
+    let value2: string | undefined
+    const unsub1 = backgroundImage.subscribe((v) => (value1 = v))
+    const unsub2 = backgroundImage.subscribe((v) => (value2 = v))
+    await setBackgroundImage(url)
+    expect(value1).toBe(url)
+    expect(value2).toBe(url)
+    unsub1()
+    unsub2()
+  })
+}) 

--- a/apps/extension/src/stores/background.svelte.ts
+++ b/apps/extension/src/stores/background.svelte.ts
@@ -1,0 +1,25 @@
+import { writable } from 'svelte/store'
+import { Logger } from '@/logger'
+
+const logger = new Logger('background-store')
+
+function fetchImage(src: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image.src)
+    image.onerror = (err) => {
+      logger.error('Failed to load image', err)
+      reject(err)
+    }
+    image.src = src
+  })
+}
+
+const { subscribe, set } = writable<string | undefined>(undefined)
+
+export const backgroundImage = { subscribe }
+
+export async function setBackgroundImage(url: string) {
+  const src = await fetchImage(url)
+  set(src)
+}

--- a/apps/extension/src/ui.test.ts
+++ b/apps/extension/src/ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { retrieveUsername, storeUsername, getMomentOfDay, setBackgroundImage } from './ui'
+import { retrieveUsername, storeUsername, getMomentOfDay } from './ui'
+import { setBackgroundImage, backgroundImage } from './stores/background.svelte'
 import browser from 'webextension-polyfill'
 import { NAME_STORAGE_KEY } from './constants';
 
@@ -72,22 +73,19 @@ describe('ui.ts', () => {
 
     afterEach(() => {
       globalThis.Image = originalImage;
-      document.documentElement.style.removeProperty('--background-image');
       vi.unstubAllGlobals();
     })
 
     it('should set the background image', async () => {
       // setup
       const mockUrl = 'https://example.com/image.jpg'
-      const mockRootElement = document.createElement('div')
-      mockRootElement.style.setProperty = vi.fn()
-      document.querySelector = vi.fn().mockReturnValue(mockRootElement)
+      let result: string | undefined
+      const unsub = backgroundImage.subscribe((v) => (result = v))
 
-      // act
       await setBackgroundImage(mockUrl)
 
-      // assert
-      expect(mockRootElement.style.setProperty).toHaveBeenCalledWith('--background-image', `url(${mockUrl})`)
+      expect(result).toBe(mockUrl)
+      unsub()
     })
   })
 })

--- a/apps/extension/src/ui.ts
+++ b/apps/extension/src/ui.ts
@@ -1,8 +1,5 @@
 import browser from 'webextension-polyfill'
 import { NAME_STORAGE_KEY } from './constants'
-import { Logger } from '@/logger'
-
-const logger = new Logger('ui')
 
 export async function retrieveUsername(): Promise<string | undefined> {
   const { [NAME_STORAGE_KEY]: name } = (await browser.storage.sync.get(
@@ -35,32 +32,3 @@ export function getMomentOfDay(): 'morning' | 'afternoon' | 'evening' {
   return momentOfDay
 }
 
-async function fetchImage(src: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const image = new Image()
-    image.onload = () => {
-      resolve(image.src)
-    }
-    image.onerror = (err) => {
-      logger.error('Failed to load image', err)
-      reject(err)
-    }
-    image.src = src
-  });
-}
-
-function setSrc(src: string) {
-  const elem = document.querySelector(':root') as HTMLElement
-
-  if (!elem) {
-    logger.error('Root element not found for setting background image')
-    return
-  }
-
-  elem.style.setProperty('--background-image', `url(${src})`)
-}
-
-export async function setBackgroundImage(url: string) {
-  const src = await fetchImage(url)
-  setSrc(src)
-}


### PR DESCRIPTION
## Summary
- create `background` store to manage background images
- add `Background` component that fades between images
- use new store in `Curtain` and `ImageRefreshButton`
- remove old background logic from `ui`
- adapt tests for new store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878d81eca748328b9e9e2c29a551764