### PR TITLE
🧹 [code health] Standardize logging in SpotifyController

### DIFF
--- a/apps/extension/src/controllers/SpotifyController.ts
+++ b/apps/extension/src/controllers/SpotifyController.ts
@@ -107,7 +107,7 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
     this.player.addListener('player_state_changed', (state) => this.playerStateChanged(state))
 
     this.player.addListener('playback_error', ({ message }) => {
-      console.error('Playback error', message)
+      this.logger.error('Playback error', message)
     })
 
     this.player.connect().then((success) => {
@@ -207,7 +207,7 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
   }
 
   async seek(position: number) {
-    console.log('Seeking to position:', position, this.isPlayerActive)
+    this.logger.log('Seeking to position:', position, this.isPlayerActive)
     if (this.isPlayerActive) {
       await this.player?.seek(position)
     } else {


### PR DESCRIPTION
Standardized logging in SpotifyController.ts by replacing direct console calls with the class's Logger instance. This ensures consistent logging behavior across the controller and respects development-only logging rules defined in the Logger implementation.

Changes:
- Replaced `console.error` with `this.logger.error` in the Spotify player's `playback_error` event listener.
- Replaced `console.log` with `this.logger.log` in the `seek` method.

---
*PR created automatically by Jules for task [17634053154345722422](https://jules.google.com/task/17634053154345722422) started by @melledijkstra*