### PR TITLE
🧪 Add unit tests for getTimePercentage

### DIFF
--- a/apps/extension/src/time/utils.test.ts
+++ b/apps/extension/src/time/utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getTimePercentage } from './utils'
+
+describe('time/utils.ts', () => {
+  describe('getTimePercentage', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should return 0% at 00:00', () => {
+      vi.setSystemTime(new Date(2024, 0, 1, 0, 0))
+      expect(getTimePercentage()).toBe('0%')
+    })
+
+    it('should return 25% at 06:00', () => {
+      vi.setSystemTime(new Date(2024, 0, 1, 6, 0))
+      expect(getTimePercentage()).toBe('25%')
+    })
+
+    it('should return 50% at 12:00', () => {
+      vi.setSystemTime(new Date(2024, 0, 1, 12, 0))
+      expect(getTimePercentage()).toBe('50%')
+    })
+
+    it('should return 75% at 18:00', () => {
+      vi.setSystemTime(new Date(2024, 0, 1, 18, 0))
+      expect(getTimePercentage()).toBe('75%')
+    })
+
+    it('should return 100% at 23:59', () => {
+      vi.setSystemTime(new Date(2024, 0, 1, 23, 59))
+      expect(getTimePercentage()).toBe('100%')
+    })
+
+    it('should handle rounding correctly (e.g., 08:30)', () => {
+      // (8 * 60 + 30) / 1440 = 510 / 1440 = 0.354166...
+      // 0.354166... * 100 = 35.4166... -> 35%
+      vi.setSystemTime(new Date(2024, 0, 1, 8, 30))
+      expect(getTimePercentage()).toBe('35%')
+    })
+
+    it('should handle rounding correctly (e.g., 08:45)', () => {
+      // (8 * 60 + 45) / 1440 = 525 / 1440 = 0.364583...
+      // 0.364583... * 100 = 36.4583... -> 36%
+      vi.setSystemTime(new Date(2024, 0, 1, 8, 45))
+      expect(getTimePercentage()).toBe('36%')
+    })
+  })
+})


### PR DESCRIPTION
🎯 **What:** Added unit tests for the \`getTimePercentage\` utility function in \`apps/extension/src/time/utils.ts\`.
📊 **Coverage:** The new test suite covers:
- Midnight (00:00) -> 0%
- Morning (06:00) -> 25%
- Noon (12:00) -> 50%
- Evening (18:00) -> 75%
- End of day (23:59) -> 100%
- Specific times to verify rounding logic (08:30, 08:45).
✨ **Result:** Improved test coverage and reliability for time-based progress calculations. Verified logic with a standalone script to ensure correctness despite environment limitations.

---
*PR created automatically by Jules for task [7141126463258106098](https://jules.google.com/task/7141126463258106098) started by @melledijkstra*