### PR TITLE
🧹 Refactor logging in SpotifyController

### DIFF
--- a/apps/extension/src/controllers/SpotifyController.ts
+++ b/apps/extension/src/controllers/SpotifyController.ts
@@ -107,7 +107,7 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
     this.player.addListener('player_state_changed', (state) => this.playerStateChanged(state))
 
     this.player.addListener('playback_error', ({ message }) => {
-      console.error('Playback error', message)
+      this.logger.error('Playback error', message)
     })
 
     this.player.connect().then((success) => {
@@ -207,7 +207,7 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
   }
 
   async seek(position: number) {
-    console.log('Seeking to position:', position, this.isPlayerActive)
+    this.logger.log('Seeking to position:', position, this.isPlayerActive)
     if (this.isPlayerActive) {
       await this.player?.seek(position)
     } else {


### PR DESCRIPTION
This PR addresses a code health issue where raw `console.log` and `console.error` statements were used in the `SpotifyController`. These have been replaced with calls to the structured `this.logger` instance.

🎯 **What:** 
- Replaced `console.log` in `seek()` method with `this.logger.log`.
- Replaced `console.error` in `playback_error` listener within `initializeSpotifyPlayer()` with `this.logger.error`.

💡 **Why:** 
Using the structured logger ensures consistency across the codebase, allows for environment-aware logging (e.g., disabling logs in production), and improves the readability and maintainability of the code.

✅ **Verification:** 
- Manually verified the file content.
- Ensured consistency with `BaseMusicController` and other logger usages in the same file.
- Confirmed that the logger automatically prefixes messages with `[SpotifyController]`.

✨ **Result:** 
The code now follows the project's logging conventions and is cleaner.

---
*PR created automatically by Jules for task [11360731277609650011](https://jules.google.com/task/11360731277609650011) started by @melledijkstra*