### PR TITLE
feat: improve Spotify UI and control logic

### DIFF
--- a/apps/extension/src/api/spotify.ts
+++ b/apps/extension/src/api/spotify.ts
@@ -135,7 +135,12 @@ export class SpotifyApiClient extends TokenBaseClient implements ILogger {
 
   async toggleRepeatMode(repeatMode: string | number): Promise<void> {
     await this.retrieveAccessToken()
-    const mode = typeof repeatMode === 'number' ? repeatMode : (repeatMode === 'off' ? 'off' : 'context')
+    let mode = 'off'
+    if (typeof repeatMode === 'number') {
+      mode = repeatMode === 1 ? 'track' : repeatMode === 2 ? 'context' : 'off'
+    } else {
+      mode = repeatMode
+    }
     
     await this.request(`/me/player/repeat?state=${mode}`, {
       method: 'PUT'

--- a/apps/extension/src/api/spotify.ts
+++ b/apps/extension/src/api/spotify.ts
@@ -138,7 +138,7 @@ export class SpotifyApiClient extends TokenBaseClient implements ILogger {
     
     let mode = 'off'
     
-    switch (typeof repeatMode === 'number' ? repeatMode : repeatMode) {
+    switch (repeatMode) {
       case 1:
         mode = 'track'
         break

--- a/apps/extension/src/api/spotify.ts
+++ b/apps/extension/src/api/spotify.ts
@@ -135,14 +135,25 @@ export class SpotifyApiClient extends TokenBaseClient implements ILogger {
 
   async toggleRepeatMode(repeatMode: string | number): Promise<void> {
     await this.retrieveAccessToken()
+    
     let mode = 'off'
-    if (typeof repeatMode === 'number') {
-      mode = repeatMode === 1 ? 'track' : repeatMode === 2 ? 'context' : 'off'
-    } else {
-      mode = repeatMode
+    
+    switch (typeof repeatMode === 'number' ? repeatMode : repeatMode) {
+      case 1:
+        mode = 'track'
+        break
+      case 2:
+        mode = 'context'
+        break
+      case 0:
+        mode = 'off'
+        break
+      default:
+        mode = repeatMode as string
+        break
     }
     
-    await this.request(`/me/player/repeat?state=${mode}`, {
+    await this.request(`/me/player/repeat?state=${encodeURIComponent(mode)}`, {
       method: 'PUT'
     })
   }

--- a/apps/extension/src/components/musicplayer/MusicPlayer.svelte
+++ b/apps/extension/src/components/musicplayer/MusicPlayer.svelte
@@ -68,6 +68,8 @@
     onNextTrack={() => controller.next()}
     onSeek={(pos) => controller.seek(pos)}
     onVolumeChange={(volume) => controller.setVolume(volume)}
+    onToggleShuffle={(shuffle) => controller.toggleShuffle?.(shuffle)}
+    onSwitchRepeatMode={(mode) => controller.switchRepeatMode?.(mode)}
   />
   <Devices
     class="col-span-2"

--- a/apps/extension/src/components/musicplayer/Playback.svelte
+++ b/apps/extension/src/components/musicplayer/Playback.svelte
@@ -45,7 +45,7 @@
 
   let isShuffling = $derived(state?.shuffle ?? false)
 
-  let repeatMode = $derived(0)
+  let repeatMode = $derived(state?.repeatMode ?? 0)
   let repeatModeIcon = $derived.by(() => {
     switch (repeatMode) {
       case 1:
@@ -144,10 +144,9 @@
         </button>
         <button
           class="cursor-pointer disabled:text-gray-500 disabled:cursor-not-allowed"
-          disabled={true}
           onclick={() => onSwitchRepeatMode?.(repeatMode === 2 ? 0 : repeatMode + 1)}
         >
-          <Icon class="size-6" path={repeatModeIcon} />
+          <Icon class="size-6 {repeatMode > 0 ? 'text-green-500' : ''}" path={repeatModeIcon} />
         </button>
       </div>
     </div>

--- a/apps/extension/src/components/musicplayer/PlaylistItem.svelte
+++ b/apps/extension/src/components/musicplayer/PlaylistItem.svelte
@@ -30,6 +30,6 @@
       class="truncate hover:underline cursor-pointer"
       onclick={() => onPlaylistSelected(playlist)}>{playlist.title}</button
     >
-    <p class="text-xs italic">X songs</p>
+    <p class="text-xs italic">{playlist.trackCount ?? 0} songs</p>
   </div>
 </div>

--- a/apps/extension/src/components/musicplayer/PlaylistItem.svelte
+++ b/apps/extension/src/components/musicplayer/PlaylistItem.svelte
@@ -13,10 +13,10 @@
 </script>
 
 <div
-  class="flex flex-row text-left w-full items-center p-2 hover:bg-neutral-400 rounded-sm transition text-white"
+  class="flex flex-row gap-2 w-full items-center p-2 hover:bg-neutral-400 rounded-sm transition text-white"
 >
   <button
-    class="cursor-pointer hover:opacity-30"
+    class="cursor-pointer hover:opacity-30 shrink-0"
     onclick={() => onPlaylistPlay(playlist)}
   >
     <img
@@ -25,9 +25,9 @@
       alt="Playlist cover"
     />
   </button>
-  <div class="flex flex-col ml-2 overflow-hidden text-sm">
+  <div class="flex flex-col overflow-hidden text-sm items-start">
     <button
-      class="truncate hover:underline cursor-pointer"
+      class="inline-block truncate hover:underline cursor-pointer"
       onclick={() => onPlaylistSelected(playlist)}>{playlist.title}</button
     >
     <p class="text-xs italic">{playlist.trackCount ?? 0} songs</p>

--- a/apps/extension/src/components/musicplayer/TrackList.svelte
+++ b/apps/extension/src/components/musicplayer/TrackList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Track } from 'MusicPlayer'
+  import { millisecondsToTime } from '@/time/utils'
 
   const { tracks, onTrackSelected }: {
     tracks: Track[]
@@ -11,9 +12,12 @@
   <button class="flex flex-row w-full text-left items-center p-2 hover:bg-neutral-400 cursor-pointer rounded-sm transition text-white"
        onclick={() => onTrackSelected(track)}>
     <img class="size-10 aspect-square" src={track.coverArtUrl ?? '/icons/album-cover-placeholder.png'} alt="Track cover" />
-    <div class="ml-2 overflow-hidden">
+    <div class="ml-2 overflow-hidden flex-1">
       <p class="truncate text-sm font-bold">{track.title}</p>
       <p class="truncate text-xs">{track.artist.name}</p>
+    </div>
+    <div class="ml-2 text-xs opacity-75">
+      {millisecondsToTime(track.duration_ms)}
     </div>
   </button>
 {/snippet}

--- a/apps/extension/src/components/musicplayer/types.ts
+++ b/apps/extension/src/components/musicplayer/types.ts
@@ -34,6 +34,7 @@ declare module 'MusicPlayer' {
     title: string;
     description?: string; // optional
     coverArtUrl?: string; // optional
+    trackCount?: number; // optional
     type: 'playlist'
   }
 
@@ -54,6 +55,8 @@ declare module 'MusicPlayer' {
     setVolume(volume: number): void;
     getPlaybackState(): Promise<PlaybackState>;
     activateDevice?(deviceId: string): void;
+    switchRepeatMode?(repeatMode: number | string): Promise<void>;
+    toggleShuffle?(enabled?: boolean): Promise<void>;
   }
 
   type PlaybackState = {
@@ -62,5 +65,6 @@ declare module 'MusicPlayer' {
     volume: number; // 0-100
     position_ms: number; // in milliseconds
     shuffle: boolean;
+    repeatMode?: number; // 0, 1, 2
   }
 }

--- a/apps/extension/src/controllers/BaseMusicController.ts
+++ b/apps/extension/src/controllers/BaseMusicController.ts
@@ -19,6 +19,7 @@ export abstract class BaseMusicController implements MusicPlayerInterface, ILogg
   abstract activateDevice?(deviceId: string): void
   abstract getPlaybackState(): Promise<PlaybackState>
   abstract toggleShuffle(enabled?: boolean): Promise<void>
+  abstract switchRepeatMode?(repeatMode: string | number): Promise<void>
   
   protected trackEnded() {
     this.stopPlaybackLoop()

--- a/apps/extension/src/controllers/SpotifyController.ts
+++ b/apps/extension/src/controllers/SpotifyController.ts
@@ -51,7 +51,8 @@ export class SpotifyController extends BaseMusicController implements ILogger {
     if (!this.api) {
       throw new Error('Spotify API client is not initialized');
     }
-    return await this.api?.toggleRepeatMode(repeatMode)
+    await this.api?.toggleRepeatMode(repeatMode);
+    await this.getPlaybackState();
   }
 
   async togglePlayPause(): Promise<void> {

--- a/apps/extension/src/controllers/SpotifyController.ts
+++ b/apps/extension/src/controllers/SpotifyController.ts
@@ -52,7 +52,7 @@ export class SpotifyController extends BaseMusicController implements ILogger {
       throw new Error('Spotify API client is not initialized');
     }
     await this.api?.toggleRepeatMode(repeatMode);
-    await this.getPlaybackState();
+    await this.syncState();
   }
 
   async togglePlayPause(): Promise<void> {
@@ -145,7 +145,7 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
         this.isPlayerActive = true;
       } else {
         this.isPlayerActive = false;
-        this.syncState()
+        await this.syncState()
       }
       spotifyState.devices = spotifyState.devices.map(device => ({
         ...device,
@@ -156,7 +156,7 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
 
   async playItem(mediaItem: Playlist | Album | Track) {
     this.logger.log('Playing item:', mediaItem.title, mediaItem)
-    this.api.play(mediaItem.uri)
+    await this.api.play(mediaItem.uri)
   }
 
   async play() {
@@ -184,7 +184,7 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
       await this.player?.nextTrack()
     } else {
       await this.api.nextTrack()
-      this.syncState()
+      await this.syncState()
     }
   }
 
@@ -193,7 +193,7 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
       await this.player?.previousTrack()
     } else {
       await this.api.previousTrack()
-      this.syncState()
+      await this.syncState()
     }
   }
 
@@ -266,6 +266,6 @@ private async initializeSpotifyPlayer(authClient: AuthClient) {
     : !this.state.playback.shuffle;
     this.logger.log('Toggling shuffle mode', { newState });
     await this.api?.toggleShuffle(newState);
-    this.getPlaybackState()
+    await this.syncState();
   }
 }

--- a/apps/extension/src/mocks/MockMusicPlayerController.ts
+++ b/apps/extension/src/mocks/MockMusicPlayerController.ts
@@ -72,4 +72,8 @@ export class MockMusicPlayerController extends BaseMusicController {
   async toggleShuffle(enabled?: boolean): Promise<void> {
     this.state.playback.shuffle = enabled ?? !this.state.playback.shuffle;
   }
+
+  async switchRepeatMode(repeatMode: number | string): Promise<void> {
+    this.state.playback.repeatMode = typeof repeatMode === 'number' ? repeatMode : 0;
+  }
 }

--- a/apps/extension/src/transforms/spotify.ts
+++ b/apps/extension/src/transforms/spotify.ts
@@ -48,6 +48,7 @@ export const convertSpotifyPlaylist = (playlist: SpotifyPlaylist): Playlist => (
   title: playlist.name,
   description: playlist.description || '',
   coverArtUrl: playlist.images[0]?.url || '',
+  trackCount: playlist.tracks?.total,
   type: 'playlist'
 })
 
@@ -59,6 +60,7 @@ export const convertApiPlaybackState = (state: ApiPlaybackState): PlaybackState 
     volume: device.volume_percent ?? 0,
     position_ms: state.progress_ms,
     shuffle: state.shuffle_state,
+    repeatMode: state.repeat_state === 'off' ? 0 : state.repeat_state === 'track' ? 1 : 2,
     currentItem: convertSpotifyTrackToMPTrack(track),
   }
 }
@@ -72,7 +74,8 @@ export const convertPlayerState = (state: Spotify.PlaybackState, currentState?: 
     isPlaying: !state.paused,
     position_ms: state.position,
     volume: currentState?.volume ?? 0,
-    shuffle: currentState?.shuffle ?? false,
+    shuffle: state.shuffle ?? currentState?.shuffle ?? false,
+    repeatMode: state.repeat_mode ?? currentState?.repeatMode ?? 0,
     currentItem: {
       id: currentTrack.uri,
       uri: currentTrack.uri,


### PR DESCRIPTION
This PR addresses several UI and controller inconsistencies in the Spotify integration:
- Shows the number of tracks in each playlist item using data returned by the API.
- Shows the duration of each track in the track list using the `millisecondsToTime` helper.
- Connects the repeat and shuffle buttons on the player directly to the Spotify controllers.
- Maps player SDK numbers and web API states into a unified internal `repeatMode` state logic (0: off, 1: track, 2: context).
- Removes obsolete disabled styling from the player playback loop buttons and gives visual hints when active.

---
*PR created automatically by Jules for task [12448088261329632808](https://jules.google.com/task/12448088261329632808) started by @melledijkstra*