### PR TITLE
fix: Context loss on saveSettingsToStorage callback

### DIFF
--- a/apps/extension/src/settings/index.svelte.ts
+++ b/apps/extension/src/settings/index.svelte.ts
@@ -123,7 +123,7 @@ export class Settings implements ILogger {
     return { ...DEFAULT_SETTINGS, ...storageSettings, loaded: true }
   }
 
-  async saveSettingsToStorage() {
+  saveSettingsToStorage = async () => {
     this.isLocalSettingsChange = true
     // make sure we don't save the loaded property to storage
     const settingsToStore = structuredClone(this.settingsCopy)


### PR DESCRIPTION
Changed `saveSettingsToStorage` in the `Settings` class to an arrow function.

Previously, passing `settings.saveSettingsToStorage` directly to Svelte component event handlers like `onchange` would cause it to lose its `this` context, leading to a crash when it attempted to access `this.isLocalSettingsChange`. Changing it to an arrow function lexically binds it to the instance, making it safe to use as a callback.

---
*PR created automatically by Jules for task [5191945912942630972](https://jules.google.com/task/5191945912942630972) started by @melledijkstra*