### PR TITLE
refactor(auth): simplify AuthConfig and introduce AuthClient singletons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,13 @@ For domain knowledge, architectural details, and coding conventions, agents MUST
 
 ## Notes for AI Agents
 
-1. **Respect Existing Conventions**: Follow the established patterns and structures in the repository as outlined in `CONTEXT.md`.
-2. **Document Contributions**: Update relevant code comments or `CONTEXT.md` when introducing new features or architectural changes.
-3. **Explicit Confirmation**: Never start the implementation phase immediately after a planning, design, or grilling session. Always explicitly confirm with the user that it is time to write code, or transition to a specific implementation workflow skill (like TDD or issue creation) before touching the codebase.
-4. **Development Workflow**: Use `pnpm` (not `npm`) for all package management commands. Always run `pnpm run local:ci` to verify the codebase is in a good state before committing any changes.
-5. **Coding Standards**: Follow formatting and linting standards dictated by Prettier and ESLint
+- **Respect Existing Conventions**: Follow the established patterns and structures in the repository as outlined in `CONTEXT.md`.
+- **Document Contributions**: Update relevant code comments or `CONTEXT.md` when introducing new features or architectural changes.
+- **Explicit Confirmation**: Never start the implementation phase immediately after a planning, design, or grilling session. Always explicitly confirm with the user that it is time to write code, or transition to a specific implementation workflow skill (like TDD or issue creation) before touching the codebase.
+- **Development Workflow**: Use `pnpm` (not `npm`) for all package management commands. Always run `pnpm run local:ci` to verify the codebase is in a good state before committing any changes.
+- **Coding Standards**: Follow formatting and linting standards dictated by Prettier and ESLint
+- Don't use `any`, instead try to actual type correctly the code, only in some special cases `unknown` can be used. If unsure, ask the user.
+- Don't silence eslint issues, instead try to tackle them and resolve the issue.
 
 ## Agent skills
 

--- a/apps/extension/src/components/DefaultModeContent.svelte
+++ b/apps/extension/src/components/DefaultModeContent.svelte
@@ -3,10 +3,9 @@
   import { storeUsername, clearUsername, retrieveUsername } from '@/browser'
   import Clock from '@/components/Clock.svelte'
   import Welcome from '@/components/Welcome.svelte'
-  import { GoogleAuthProvider } from '@/oauth2/providers'
+  import { googleAuthClient } from '@/oauth2/clients'
   import { settingsStore } from '@/settings/index.svelte'
   import { GoogleTasksApiClient } from '@melledijkstra/api'
-  import { AuthClient } from '@melledijkstra/extension'
   import { createQuery } from '@tanstack/svelte-query'
   import { onMount } from 'svelte'
 
@@ -15,10 +14,9 @@
   const tasksQuery = createQuery(() => ({
     queryKey: ['tasks', 'google', 'tasks', taskListId],
     queryFn: async () => {
-      const auth = new AuthClient(new GoogleAuthProvider())
-      const isAuthenticated = await auth.isAuthenticated()
+      const isAuthenticated = await googleAuthClient.isAuthenticated()
       if (!isAuthenticated) return []
-      const client = new GoogleTasksApiClient(auth)
+      const client = new GoogleTasksApiClient(googleAuthClient)
       return (await client.fetchTasks(taskListId)) ?? []
     },
     staleTime: 5 * 60 * 1000,

--- a/apps/extension/src/components/settings-tabs/AuthenticationTab.svelte
+++ b/apps/extension/src/components/settings-tabs/AuthenticationTab.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import { settingsStore, settings } from '@/settings/index.svelte'
   import AuthButton from '@/components/AuthButton.svelte'
-  import { AuthClient } from '@melledijkstra/extension'
+  import { type OauthProvider } from '@/oauth2/providers'
   import {
-    GoogleAuthProvider,
-    SpotifyAuthProvider,
-    GithubAuthProvider,
-    type OauthProvider,
-  } from '@/oauth2/providers'
+    googleAuthClient,
+    spotifyAuthClient,
+    githubAuthClient,
+  } from '@/oauth2/clients'
   import Input from '@melledijkstra/ui/svelte/Input.svelte'
   import Spinner from '@melledijkstra/ui/svelte/Spinner.svelte'
   import { onMount, onDestroy } from 'svelte'
@@ -17,9 +16,9 @@
   const logger = new Logger('AuthenticationTab')
 
   const clients = {
-    google: new AuthClient(new GoogleAuthProvider()),
-    spotify: new AuthClient(new SpotifyAuthProvider()),
-    github: new AuthClient(new GithubAuthProvider()),
+    google: googleAuthClient,
+    spotify: spotifyAuthClient,
+    github: githubAuthClient,
   } as const
 
   const authState = $state({

--- a/apps/extension/src/components/topbar/Account.svelte
+++ b/apps/extension/src/components/topbar/Account.svelte
@@ -2,11 +2,9 @@
   import { onMount } from 'svelte'
   import { ACCOUNT_CACHE_KEY } from '../../constants'
   import { GoogleAccountApiClient, type Account } from '@melledijkstra/api'
-  import { AuthClient } from '@melledijkstra/extension'
-  import { GoogleAuthProvider } from '@/oauth2/providers'
+  import { googleAuthClient } from '@/oauth2/clients'
 
-  const auth = new AuthClient(new GoogleAuthProvider())
-  const client = new GoogleAccountApiClient(auth)
+  const client = new GoogleAccountApiClient(googleAuthClient)
 
   let accountInfo = $state<Account>()
 

--- a/apps/extension/src/components/topbar/MetricsBar.svelte
+++ b/apps/extension/src/components/topbar/MetricsBar.svelte
@@ -5,15 +5,12 @@
   import Countdown from '../atoms/metrics/Countdown.svelte'
   import { onMount } from 'svelte'
   import Sleep from '../atoms/metrics/Sleep.svelte'
-  import { AuthClient } from '@melledijkstra/extension'
-  import { GoogleAuthProvider } from '@/oauth2/providers'
+  import { googleAuthClient } from '@/oauth2/clients'
   import { GoogleHealthApiClient } from '@melledijkstra/api'
 
   const cache = new WebLocalStorage()
 
   const STORAGE_KEY = 'googlehealth::sleep_minutes'
-
-  const authClient = new AuthClient(new GoogleAuthProvider())
 
   let client = $state<GoogleHealthApiClient>()
 
@@ -27,21 +24,21 @@
     'https://www.googleapis.com/auth/googlehealth.sleep.readonly'
 
   async function getSleepData() {
-    const grantedScopes = await authClient.getGrantedScopes()
+    const grantedScopes = await googleAuthClient.getGrantedScopes()
     if (!grantedScopes.includes(sleepScope)) {
       console.log('No sleep scope granted')
       return
     }
 
     if (!client) {
-      client = new GoogleHealthApiClient(authClient)
+      client = new GoogleHealthApiClient(googleAuthClient)
     }
     sleepMinutes = await client.getSleep()
     await cache.set(STORAGE_KEY, sleepMinutes, 60 * 60 * 1000) // Cache for 1 hour
   }
 
   async function authenticate() {
-    const tokenData = await authClient.getAuthToken(true, [sleepScope])
+    const tokenData = await googleAuthClient.getAuthToken(true, [sleepScope])
     if (tokenData) {
       getSleepData()
     }

--- a/apps/extension/src/controllers/GithubTasksController.ts
+++ b/apps/extension/src/controllers/GithubTasksController.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest'
 import { AuthClient } from '@melledijkstra/extension'
-import { GithubAuthProvider } from '@/oauth2/providers'
+import { githubAuthClient } from '@/oauth2/clients'
 import type { Task, TaskList } from '@/interfaces/tasks'
 import type { TaskControllerInterface } from './GoogleTasksController'
 import type { ILogger } from '@/interfaces/logger.interface'
@@ -41,7 +41,7 @@ export class GithubTasksController implements TaskControllerInterface, ILogger {
 
   constructor() {
     this.logger = new Logger('GithubTasksController')
-    this.auth = new AuthClient(new GithubAuthProvider())
+    this.auth = githubAuthClient
   }
 
   async authenticate(): Promise<boolean> {

--- a/apps/extension/src/controllers/GoogleTasksController.ts
+++ b/apps/extension/src/controllers/GoogleTasksController.ts
@@ -2,7 +2,7 @@ import { GoogleTasksApiClient } from '@melledijkstra/api'
 import type { ILogger } from '@/interfaces/logger.interface'
 import { Logger } from '@/logger'
 import { AuthClient } from '@melledijkstra/extension'
-import { GoogleAuthProvider } from '@/oauth2/providers'
+import { googleAuthClient } from '@/oauth2/clients'
 import { addNotification } from '@/stores/notifications.svelte'
 import type { Task, TaskList } from '@/interfaces/tasks'
 
@@ -32,7 +32,7 @@ export class GoogleTasksController implements TaskControllerInterface, ILogger {
 
   constructor() {
     this.logger = new Logger('GoogleTasksController')
-    this.auth = new AuthClient(new GoogleAuthProvider())
+    this.auth = googleAuthClient
     this.api = new GoogleTasksApiClient(this.auth)
   }
 

--- a/apps/extension/src/controllers/SpotifyController.ts
+++ b/apps/extension/src/controllers/SpotifyController.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@/logger'
 import { spotifyState } from '@/modules/spotify/spotify.state.svelte'
 import { AuthClient } from '@melledijkstra/extension'
-import { SpotifyAuthProvider } from '@/oauth2/providers'
+import { spotifyAuthClient } from '@/oauth2/clients'
 import type { Album, PlaybackState, Playlist, Track } from 'MusicPlayer'
 import type { ILogger } from '@/interfaces/logger.interface'
 import { convertPlayerState } from '@/transforms/spotify'
@@ -13,7 +13,7 @@ import { SpotifyApiService } from '@/services/SpotifyApiService'
 export class SpotifyController extends BaseMusicController implements ILogger {
   logger: Logger = new Logger('SpotifyController')
 
-  protected authClient: AuthClient = new AuthClient(new SpotifyAuthProvider())
+  protected authClient: AuthClient = spotifyAuthClient
   protected playerService: SpotifyPlayerService
   protected apiService: SpotifyApiService
 

--- a/apps/extension/src/modules/tasks/index.ts
+++ b/apps/extension/src/modules/tasks/index.ts
@@ -1,15 +1,13 @@
 import type { Module } from '@/modules'
 import TasksMenuItem from './TasksMenuItem.svelte'
 import { GoogleTasksApiClient } from '@melledijkstra/api'
-import { GoogleAuthProvider } from '@/oauth2/providers'
-import { AuthClient } from '@melledijkstra/extension'
+import { googleAuthClient } from '@/oauth2/clients'
 import { queryClient } from '@/queryClient'
 
 export default {
   component: TasksMenuItem,
   init: async () => {
-    const auth = new AuthClient(new GoogleAuthProvider())
-    const client = new GoogleTasksApiClient(auth)
+    const client = new GoogleTasksApiClient(googleAuthClient)
     await queryClient.prefetchQuery({
       queryKey: ['tasks', 'google', 'lists'],
       queryFn: () => client.getTaskLists(),

--- a/apps/extension/src/oauth2/clients.ts
+++ b/apps/extension/src/oauth2/clients.ts
@@ -1,0 +1,10 @@
+import { AuthClient } from '@melledijkstra/extension'
+import {
+  getGithubAuthConfig,
+  getGoogleAuthConfig,
+  getSpotifyAuthConfig,
+} from './providers'
+
+export const githubAuthClient = new AuthClient(getGithubAuthConfig())
+export const googleAuthClient = new AuthClient(getGoogleAuthConfig())
+export const spotifyAuthClient = new AuthClient(getSpotifyAuthConfig())

--- a/apps/extension/src/oauth2/providers.ts
+++ b/apps/extension/src/oauth2/providers.ts
@@ -1,59 +1,50 @@
+import type { AuthConfig, OauthProvider } from '@melledijkstra/auth'
 import { settingsStore } from '@/settings/index.svelte'
-import {
-  GoogleAuthConfig,
-  SpotifyAuthConfig,
-  GithubAuthConfig,
-} from '@melledijkstra/auth'
+export type { OauthProvider }
 
-export type OauthProvider = 'google' | 'spotify' | 'github'
-
-export class GithubAuthProvider extends GithubAuthConfig {
+export const getGithubAuthConfig = (): AuthConfig => ({
+  name: 'github',
   get clientId() {
     return settingsStore.apiKeys.github_client_id || ''
-  }
-
+  },
   get clientSecret() {
     return settingsStore.apiKeys.github_client_secret || ''
-  }
+  },
+  scopes: ['repo'],
+})
 
-  scopes = ['repo']
-}
-
-export class GoogleAuthProvider extends GoogleAuthConfig {
-  redirectPath = 'google'
-
+export const getGoogleAuthConfig = (): AuthConfig => ({
+  name: 'google',
+  redirectPath: 'google',
   get clientId() {
     return settingsStore.apiKeys.google_client_id || ''
-  }
-
+  },
   get clientSecret() {
     return settingsStore.apiKeys.google_client_secret || ''
-  }
-
-  scopes = [
+  },
+  scopes: [
     'profile',
     'email',
     'openid',
     'https://www.googleapis.com/auth/userinfo.profile',
-  ]
-
-  extraParams = {
+  ],
+  extraParams: {
     include_granted_scopes: 'true',
     access_type: 'offline',
     prompt: 'consent',
-  }
-}
+  },
+})
 
-export class SpotifyAuthProvider extends SpotifyAuthConfig {
+export const getSpotifyAuthConfig = (): AuthConfig => ({
+  name: 'spotify',
   get clientId() {
     return settingsStore.apiKeys.spotify || ''
-  }
-
-  scopes = [
+  },
+  scopes: [
     'streaming',
     'app-remote-control',
     'user-read-playback-state',
     'user-modify-playback-state',
     'playlist-read-private',
-  ]
-}
+  ],
+})

--- a/apps/looper/google-auth.ts
+++ b/apps/looper/google-auth.ts
@@ -1,4 +1,4 @@
-import { AuthClient, GoogleAuthConfig } from '@melledijkstra/auth'
+import { AuthClient, createGoogleAuthConfig } from '@melledijkstra/auth'
 import { FileStorage } from '@melledijkstra/storage'
 import path from 'path'
 import dotenv from 'dotenv'
@@ -12,7 +12,7 @@ const storage = new FileStorage(storagePath)
 const redirectUri =
   process.env['GOOGLE_REDIRECT_URI'] || 'http://localhost:5050/oauth/callback'
 
-const config = new GoogleAuthConfig()
+const config = createGoogleAuthConfig()
 // Override scope if specified in environment variables
 if (process.env['GOOGLE_SCOPES']) {
   config.scopes = process.env['GOOGLE_SCOPES'].split(' ')

--- a/packages/api/src/tokenbaseclient.ts
+++ b/packages/api/src/tokenbaseclient.ts
@@ -24,7 +24,7 @@ export class TokenBaseClient extends BaseClient {
     const baseHeaders = await super._getHeaders()
 
     if (!token) {
-      return baseHeaders
+      throw new Error('Authentication token is missing or undefined.')
     }
 
     return {

--- a/packages/auth/example/authentication.ts
+++ b/packages/auth/example/authentication.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'node:http'
-import { AuthClient, GoogleAuthConfig } from '../src'
+import { AuthClient, createGoogleAuthConfig } from '../src'
 
 // const clientId = process.env.GITHUB_CLIENT_ID
 // const clientSecret = process.env.GITHUB_CLIENT_SECRET
@@ -8,7 +8,7 @@ import { AuthClient, GoogleAuthConfig } from '../src'
 const PORT = 8000
 const redirectUrl = `http://localhost:${PORT}/oauth/callback`
 
-const authClient = new AuthClient(new GoogleAuthConfig(), redirectUrl)
+const authClient = new AuthClient(createGoogleAuthConfig(), redirectUrl)
 
 console.log('Trying to authenticate...')
 

--- a/packages/auth/example/cli-auth.ts
+++ b/packages/auth/example/cli-auth.ts
@@ -8,9 +8,9 @@ import {
   OauthProvider,
 } from '../src'
 import {
-  SpotifyAuthConfig,
-  GithubAuthConfig,
-  GoogleAuthConfig,
+  createSpotifyAuthConfig,
+  createGithubAuthConfig,
+  createGoogleAuthConfig,
 } from '../src/providers'
 
 const rl = readline.createInterface({ input, output })
@@ -34,13 +34,13 @@ try {
 
   switch (providerName) {
     case 'google':
-      config = new GoogleAuthConfig()
+      config = createGoogleAuthConfig()
       break
     case 'github':
-      config = new GithubAuthConfig()
+      config = createGithubAuthConfig()
       break
     case 'spotify':
-      config = new SpotifyAuthConfig()
+      config = createSpotifyAuthConfig()
       break
     default:
       console.error(`Error: Unsupported provider '${providerName}'`)

--- a/packages/auth/src/auth-client.test.ts
+++ b/packages/auth/src/auth-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { AuthClient, AuthFlowHandler } from './auth-client'
-import { GoogleAuthConfig } from './providers'
+import { createGoogleAuthConfig, type AuthConfig } from './providers'
 import { MemoryCache } from '@melledijkstra/storage'
 import {
   OAuth2Tokens,
@@ -43,7 +43,7 @@ describe('AuthClient', () => {
   let storage: MemoryCache
   let handler: AuthFlowHandler
   let client: AuthClient
-  let googleAuth: GoogleAuthConfig
+  let googleAuth: AuthConfig
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -51,7 +51,7 @@ describe('AuthClient', () => {
     handler = {
       open: vi.fn(),
     }
-    googleAuth = new GoogleAuthConfig()
+    googleAuth = createGoogleAuthConfig()
     client = new AuthClient(googleAuth, 'http://localhost:3000/callback', {
       storage,
       handler,

--- a/packages/auth/src/auth-client.ts
+++ b/packages/auth/src/auth-client.ts
@@ -34,8 +34,8 @@ export interface AuthFlowHandler {
 }
 
 export class AuthClient {
-  protected _arcticClient: ArcticClient
   protected _storage: IStorage
+  protected _redirectUrl: string
   protected _state: string | undefined
   protected _codeVerifier: string | undefined
   protected _logger: Logger
@@ -56,37 +56,43 @@ export class AuthClient {
   ) {
     this._logger = new Logger(`auth:${provider.name}`)
     this.provider = provider
+    this._redirectUrl = redirectUrl
     this._storage = storage
     this._handler = handler
-    switch (provider.name) {
+  }
+
+  /**
+   * Intentionally instantiates a new ArcticClient on every call rather than caching.
+   * This ensures that if the underlying credentials (like settingsStore API keys)
+   * change dynamically at runtime, the latest credentials are always used.
+   * Instantiating these classes is virtually zero cost.
+   */
+  protected get _arcticClient(): ArcticClient {
+    switch (this.provider.name) {
       case 'google':
-        this._arcticClient = new Google(
-          provider.clientId,
-          provider.clientSecret ?? '',
-          redirectUrl
+        return new Google(
+          this.provider.clientId,
+          this.provider.clientSecret ?? '',
+          this._redirectUrl
         )
-        break
       case 'spotify':
-        this._arcticClient = new Spotify(
-          provider.clientId,
-          provider.clientSecret ?? null,
-          redirectUrl
+        return new Spotify(
+          this.provider.clientId,
+          this.provider.clientSecret ?? null,
+          this._redirectUrl
         )
-        break
       case 'github':
-        this._arcticClient = new GitHub(
-          provider.clientId,
-          provider.clientSecret ?? '',
-          redirectUrl
+        return new GitHub(
+          this.provider.clientId,
+          this.provider.clientSecret ?? '',
+          this._redirectUrl
         )
-        break
       default:
-        this._arcticClient = new OAuth2Client(
-          provider.clientId,
-          provider.clientSecret ?? null,
-          redirectUrl
+        return new OAuth2Client(
+          this.provider.clientId,
+          this.provider.clientSecret ?? null,
+          this._redirectUrl
         )
-        break
     }
   }
 

--- a/packages/auth/src/auth-client.ts
+++ b/packages/auth/src/auth-client.ts
@@ -187,16 +187,14 @@ export class AuthClient {
     if (error instanceof OAuth2RequestError && error.code === 'invalid_grant') {
       return true
     }
-    if (
-      error instanceof UnexpectedErrorResponseBodyError &&
-      error.data &&
-      typeof error.data === 'object' &&
-      'errors' in error.data &&
-      Array.isArray(error.data?.errors)
-    ) {
-      const errors: Array<{ errorType: string; message: string }> =
-        error.data.errors
-      if (errors.some((e) => e.errorType === 'invalid_grant')) {
+    if (error instanceof UnexpectedErrorResponseBodyError) {
+      const errors = (error.data as Record<string, unknown>)?.errors
+      if (
+        Array.isArray(errors) &&
+        errors.some(
+          (e: Record<string, unknown>) => e?.errorType === 'invalid_grant'
+        )
+      ) {
         return true
       }
     }

--- a/packages/auth/src/providers.ts
+++ b/packages/auth/src/providers.ts
@@ -1,5 +1,7 @@
 import { Google, GitHub, OAuth2Client, Spotify } from 'arctic'
 
+export { Google, GitHub, OAuth2Client, Spotify }
+
 export type ArcticClient = Google | GitHub | Spotify | OAuth2Client
 
 export type OauthProvider = 'google' | 'spotify' | 'github'

--- a/packages/auth/src/providers.ts
+++ b/packages/auth/src/providers.ts
@@ -3,66 +3,50 @@ import { Google, GitHub, OAuth2Client, Spotify } from 'arctic'
 export type ArcticClient = Google | GitHub | Spotify | OAuth2Client
 
 export type OauthProvider = 'google' | 'spotify' | 'github'
-export abstract class AuthConfig {
+export interface AuthConfig {
   name: OauthProvider
-
   scopes: string[]
+  clientId: string
+  clientSecret?: string
   authEndpoint?: string
   tokenEndpoint?: string
   extraParams?: Record<string, string>
   redirectPath?: string
-
-  constructor(name: OauthProvider, scopes: string[]) {
-    this.name = name
-    this.scopes = scopes
-  }
-
-  abstract get clientId(): string
-  abstract get clientSecret(): string | undefined
 }
 
-export class GoogleAuthConfig extends AuthConfig {
-  constructor() {
-    super('google', ['openid', 'profile'])
-    this.extraParams = {
-      access_type: 'offline',
-      prompt: 'consent',
-    }
-  }
-
-  get clientId(): string {
+export const createGoogleAuthConfig = (): AuthConfig => ({
+  name: 'google',
+  scopes: ['openid', 'profile'],
+  get clientId() {
     return process.env.GOOGLE_CLIENT_ID!
-  }
+  },
+  get clientSecret() {
+    return process.env.GOOGLE_CLIENT_SECRET
+  },
+  extraParams: {
+    access_type: 'offline',
+    prompt: 'consent',
+  },
+})
 
-  get clientSecret(): string | undefined {
-    return process.env.GOOGLE_CLIENT_SECRET!
-  }
-}
-
-export class GithubAuthConfig extends AuthConfig {
-  constructor() {
-    super('github', ['user'])
-  }
-
-  get clientId(): string {
+export const createGithubAuthConfig = (): AuthConfig => ({
+  name: 'github',
+  scopes: ['user'],
+  get clientId() {
     return process.env.GITHUB_CLIENT_ID!
-  }
+  },
+  get clientSecret() {
+    return process.env.GITHUB_CLIENT_SECRET
+  },
+})
 
-  get clientSecret(): string | undefined {
-    return process.env.GITHUB_CLIENT_SECRET!
-  }
-}
-
-export class SpotifyAuthConfig extends AuthConfig {
-  constructor() {
-    super('spotify', ['user'])
-  }
-
-  get clientId(): string {
+export const createSpotifyAuthConfig = (): AuthConfig => ({
+  name: 'spotify',
+  scopes: ['user'],
+  get clientId() {
     return process.env.SPOTIFY_CLIENT_ID!
-  }
-
-  get clientSecret(): string | undefined {
-    return process.env.SPOTIFY_CLIENT_SECRET!
-  }
-}
+  },
+  get clientSecret() {
+    return process.env.SPOTIFY_CLIENT_SECRET
+  },
+})

--- a/packages/extension/src/auth.spec.ts
+++ b/packages/extension/src/auth.spec.ts
@@ -8,10 +8,11 @@ describe('Extension AuthClient', () => {
 
     const provider: AuthConfig = {
       name: 'google',
-      clientId: 'test-client-id',
+      get clientId() {
+        return 'test-client-id'
+      },
       tokenEndpoint: 'https://oauth2.googleapis.com/token',
       scopes: ['openid', 'profile', 'email'],
-      clientSecret: 'test-client-secret',
     }
     const authClient = new AuthClient(provider)
     expect(authClient).toBeInstanceOf(AuthClient)


### PR DESCRIPTION
- Replaced abstract AuthConfig class hierarchy with a simple interface and factory functions
- Centralized AuthClient instantiation as singletons in apps/extension
- Added fail-fast missing token check in TokenBaseClient
- Simplified isInvalidTokenError logic with optional chaining