### PR TITLE
feat: Add counter tracker metric

### DIFF
--- a/apps/extension/src/components/atoms/metrics/Counter.svelte
+++ b/apps/extension/src/components/atoms/metrics/Counter.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { CounterMetric } from '@/modules/trackers/types'
+  import { trackers } from '@/modules/trackers/state.svelte'
+  import { fade } from 'svelte/transition'
+  import { mdiMinus, mdiPlus } from '@mdi/js'
+  import IconButton from '@melledijkstra/ui/svelte/IconButton.svelte'
+
+  const { metric }: { metric: CounterMetric } = $props()
+
+  function increment() {
+    trackers.updateMetric(metric.id, { value: metric.value + 1 })
+  }
+
+  function decrement() {
+    trackers.updateMetric(metric.id, { value: metric.value - 1 })
+  }
+</script>
+
+<div transition:fade class="flex items-center gap-2 group/counter dark:text-white text-black bg-white/5 hover:bg-white/10 px-2 py-1 rounded-lg border border-white/10 transition-colors relative overflow-hidden">
+  <div class="flex flex-col text-right">
+    <p class="text-base font-bold leading-none">{metric.value}</p>
+    <p class="text-[0.65rem] opacity-70 leading-none mt-1">{metric.name}</p>
+  </div>
+
+  <div class="flex flex-col opacity-0 group-hover/counter:opacity-100 transition-opacity absolute right-0 inset-y-0 bg-zinc-800/90 items-center justify-center border-l border-white/10">
+    <IconButton
+      icon={mdiPlus}
+      size={16}
+      onclick={increment}
+      class="hover:text-primary !p-0.5 rounded-none rounded-tr border-b border-white/10 h-1/2 w-5 flex items-center justify-center"
+    />
+    <IconButton
+      icon={mdiMinus}
+      size={16}
+      onclick={decrement}
+      class="hover:text-primary !p-0.5 rounded-none rounded-br h-1/2 w-5 flex items-center justify-center"
+    />
+  </div>
+</div>

--- a/apps/extension/src/components/atoms/metrics/Counter.svelte
+++ b/apps/extension/src/components/atoms/metrics/Counter.svelte
@@ -4,6 +4,7 @@
   import { fade } from 'svelte/transition'
   import { mdiMinus, mdiPlus } from '@mdi/js'
   import IconButton from '@melledijkstra/ui/svelte/IconButton.svelte'
+  import { Tracker } from '@melledijkstra/ui/svelte'
 
   const { metric }: { metric: CounterMetric } = $props()
 
@@ -16,24 +17,27 @@
   }
 </script>
 
-<div transition:fade class="flex items-center gap-2 group/counter dark:text-white text-black bg-white/5 hover:bg-white/10 px-2 py-1 rounded-lg border border-white/10 transition-colors relative overflow-hidden">
-  <div class="flex flex-col text-right">
-    <p class="text-base font-bold leading-none">{metric.value}</p>
-    <p class="text-[0.65rem] opacity-70 leading-none mt-1">{metric.name}</p>
-  </div>
-
-  <div class="flex flex-col opacity-0 group-hover/counter:opacity-100 transition-opacity absolute right-0 inset-y-0 bg-zinc-800/90 items-center justify-center border-l border-white/10">
-    <IconButton
-      icon={mdiPlus}
-      size={16}
-      onclick={increment}
-      class="hover:text-primary !p-0.5 rounded-none rounded-tr border-b border-white/10 h-1/2 w-5 flex items-center justify-center"
-    />
-    <IconButton
-      icon={mdiMinus}
-      size={16}
-      onclick={decrement}
-      class="hover:text-primary !p-0.5 rounded-none rounded-br h-1/2 w-5 flex items-center justify-center"
-    />
-  </div>
+<div transition:fade>
+  <Tracker.Root
+    class="group/counter flex items-center gap-2 bg-white/5 hover:bg-white/10 px-2 py-2 rounded-lg border border-white/10 transition-colors relative overflow-hidden"
+  >
+    <Tracker.Metric>{metric.value}</Tracker.Metric>
+    <Tracker.Title>{metric.name}</Tracker.Title>
+    <div
+      class="flex flex-row opacity-0 group-hover/counter:opacity-100 transition-opacity absolute bottom-0 inset-x-0 bg-slate-500/90 items-center justify-center border-l border-white/10"
+    >
+      <IconButton
+        icon={mdiMinus}
+        size={16}
+        onclick={decrement}
+        class="hover:text-primary p-0.5 rounded-none rounded-br h-1/2 w-5 flex items-center justify-center"
+      />
+      <IconButton
+        icon={mdiPlus}
+        size={16}
+        onclick={increment}
+        class="hover:text-primary p-0.5 rounded-none rounded-tr border-b border-white/10 h-1/2 w-5 flex items-center justify-center"
+      />
+    </div>
+  </Tracker.Root>
 </div>

--- a/apps/extension/src/components/topbar/MetricsBar.svelte
+++ b/apps/extension/src/components/topbar/MetricsBar.svelte
@@ -3,6 +3,7 @@
   import { trackers } from '@/modules/trackers/state.svelte'
   import Clock from '@/components/atoms/metrics/WorldClock.svelte'
   import Countdown from '../atoms/metrics/Countdown.svelte'
+  import Counter from '../atoms/metrics/Counter.svelte'
   import { onMount } from 'svelte'
   import Sleep from '../atoms/metrics/Sleep.svelte'
   import { googleHealthAuthClient } from '@/oauth2/clients'
@@ -122,10 +123,7 @@
           </div>
         {/if}
       {:else if metric.type === 'counter'}
-        <div class="dark:text-white text-black rounded-lg text-right">
-          <p class="text-base leading-none">{metric.value}</p>
-          <p class="text-xs">{metric.name}</p>
-        </div>
+        <Counter {metric} />
       {/if}
     {/each}
   </div>

--- a/apps/extension/src/modules/trackers/MetricsPanel.svelte
+++ b/apps/extension/src/modules/trackers/MetricsPanel.svelte
@@ -13,6 +13,7 @@
     mdiDrag,
   } from '@mdi/js'
   import CountdownForm from './countdown/Form.svelte'
+  import CounterForm from './counter/Form.svelte'
   import WorldClockForm from './world-clocks/Form.svelte'
   import Countdown from '@/components/atoms/metrics/Countdown.svelte'
   import Clock from '@/components/atoms/metrics/WorldClock.svelte'
@@ -229,8 +230,7 @@
       <WorldClockForm onSubmitted={backToMain} />
     {:else if currentForm === 'counter'}
       <h2 class="text-lg mb-3">Counters 🔢</h2>
-      <!-- Placeholder for future counter form -->
-      <p>Counter form not yet implemented.</p>
+      <CounterForm onSubmitted={backToMain} />
     {/if}
   </PopPanel>
 </Popover.Root>

--- a/apps/extension/src/modules/trackers/counter/Form.svelte
+++ b/apps/extension/src/modules/trackers/counter/Form.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import Icon from '@melledijkstra/ui/svelte/Icon.svelte'
+  import Toggle from '@melledijkstra/ui/svelte/Toggle.svelte'
+  import { trackers } from '../state.svelte'
+  import { mdiNumeric } from '@mdi/js'
+  import Input from '@melledijkstra/ui/svelte/Input.svelte'
+  import Button from '@melledijkstra/ui/svelte/Button.svelte'
+
+  const { onSubmitted }: { onSubmitted?: () => void } = $props()
+
+  let inputName = $state('')
+  let inputPinned = $state(false)
+
+  function resetForm() {
+    inputName = ''
+    inputPinned = false
+  }
+</script>
+
+<form
+  class="flex flex-col gap-4 text-left"
+  onsubmit={(e) => {
+    e.preventDefault()
+    trackers.addCounter(inputName, 0, inputPinned)
+    onSubmitted?.()
+    resetForm()
+  }}
+>
+  <div class="space-y-3">
+    <Input
+      label="Name"
+      placeholder="e.g. Cups of Coffee"
+      required
+      type="text"
+      bind:value={inputName}
+    />
+    <Toggle bind:checked={inputPinned} label="Pin to Top Bar" />
+  </div>
+  <Button class="w-full justify-center mt-2" type="submit">
+    <Icon size={18} path={mdiNumeric} class="mr-2" /> Add Counter
+  </Button>
+</form>

--- a/packages/ui/src/svelte/tracker/Tracker.svelte
+++ b/packages/ui/src/svelte/tracker/Tracker.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" module>
+<script lang="ts">
   import type { Snippet } from 'svelte'
   import type { ClassValue } from 'svelte/elements'
 
@@ -6,10 +6,8 @@
     class?: ClassValue
     children?: Snippet
   }
-</script>
 
-<script lang="ts">
-  const { class: className, children }: TrackerProps = $props()
+  let { class: className, children }: TrackerProps = $props()
 </script>
 
 <div class={['dark:text-white text-black', className]}>


### PR DESCRIPTION
Closes https://github.com/melledijkstra/odysea/issues/288

- Added `Counter.svelte` component to display and interact with counter metrics.
- Added `Form.svelte` to `apps/extension/src/modules/trackers/counter/` to create counter trackers.
- Rendered the `CounterForm` inside the `MetricsPanel.svelte` for adding new counters.
- Rendered `Counter.svelte` instead of raw HTML for pinned metrics in `MetricsBar.svelte`.

---
*PR created automatically by Jules for task [17981687864768820261](https://jules.google.com/task/17981687864768820261) started by @melledijkstra*